### PR TITLE
fix: Correct YAML syntax in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -20,8 +20,7 @@ services:
   - type: pserv
     name: mongodb
     plan: free
-    image:
-      url: docker.io/bitnami/mongodb:4.4
+    image: docker.io/bitnami/mongodb:4.4
     env:
       - key: MONGODB_USERNAME
         generateValue: true


### PR DESCRIPTION
The previous `render.yaml` file had a parsing error ("could not marshal seq into file") due to an incorrect structure for the `image` key in the MongoDB service definition.

This commit corrects the syntax by changing the `image` key to accept a direct string value instead of a map with a `url` key. This resolves the parsing issue and should allow Render to correctly process the blueprint file.