### PR TITLE
feat: Use external MongoDB for persistence

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,29 +8,5 @@ services:
     buildCommand: "./.render-build.sh"
     startCommand: "npm start"
     envVars:
-      - key: DATABASE_URL
-        fromService:
-          type: pserv
-          name: mongodb
-          property: connectionString
       - key: NODE_VERSION
         value: "14.17.0" # You can change this to your desired Node.js version
-
-  # Database service for MongoDB
-  - type: pserv
-    name: mongodb
-    plan: free
-    image: docker.io/bitnami/mongodb:4.4
-    env:
-      - key: MONGODB_USERNAME
-        generateValue: true
-      - key: MONGODB_PASSWORD
-        generateValue: true
-      - key: MONGODB_DATABASE
-        generateValue: true
-      - key: MONGODB_ROOT_PASSWORD
-        generateValue: true
-    volume:
-      name: mongodb-data
-      mountPath: /bitnami/mongodb
-      sizeGB: 1


### PR DESCRIPTION
This commit updates the `render.yaml` to remove the private database service definition.

The application is now configured to be deployed as a standalone web service on Render. It is intended to connect to an external database (e.g., MongoDB Atlas) for data persistence.

This change is necessary because free-tier private services on Render do not support the persistent volumes required by a database. The `DATABASE_URL` environment variable must now be set manually in the Render dashboard.