### PR TITLE
Fix: Use relative URL for API data fetch

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const brandColors = getBrandColors();
 
-    fetch('http://localhost:3000/api/data')
+    fetch('/api/data')
         .then(response => response.json())
         .then(data => {
             renderOfficeInfrastructureChart(data.officeInfrastructure, brandColors);


### PR DESCRIPTION
The charts on index.html were not displaying because the frontend code was fetching data from a hardcoded `http://localhost:3000` URL. This fails when the application is deployed to a different environment.

This commit changes the fetch URL from an absolute path to a relative path (`/api/data`), ensuring that the API calls work correctly regardless of the deployment environment.