### PR TITLE
Fix: Correct data aggregation for office infrastructure table

### DIFF
--- a/server.js
+++ b/server.js
@@ -173,7 +173,7 @@ app.get('/api/data', async (req, res) => {
             goodCondition: surveys.reduce((acc, s) => acc + (s.classroomsGood || 0), 0),
             needed: surveys.reduce((acc, s) => acc + (s.classroomsRequired || 0), 0),
             majorRepairs: surveys.reduce((acc, s) => acc + (s.classroomsMajorRepair || 0), 0),
-            renovationRequired: surveys.reduce((acc, s) => acc + (s.cubicleRenovation || 0), 0), // Assuming cubicleRenovation is for offices
+            renovationRequired: surveys.reduce((acc, s) => acc + (s.classroomsMajorRepair || 0), 0), // Changed to classroomsMajorRepair
             additionalNeeded: surveys.reduce((acc, s) => acc + (s.classroomsRequired || 0), 0),
             chart: {
                 labels: surveys.map(s => s.lgea),


### PR DESCRIPTION
The table for "Office Infrastructure" on the main page was not correctly displaying data from the survey. This was due to an incorrect data mapping in the `/api/data` endpoint in `server.js`.

The `renovationRequired` field was being populated from `cubicleRenovation`, which is related to toilets, not offices/classrooms.

A detailed analysis of the `survey.html` form revealed that there is no section for "Office Infrastructure". The data for this table is intended to come from the "Classroom Condition" section of the form.

The `classroomsMajorRepair` field in the form is explicitly labeled "Number in need of Major Repair/Renovation". This commit updates the `renovationRequired` field in the `officeInfrastructure` data aggregation to use the `classroomsMajorRepair` value, which correctly reflects the data collected in the survey.

While the user reported that "all tables" were incorrect, a thorough review of the data aggregation for the other tables (`toiletFacilities` and `staffing`) showed that they were being populated correctly. This commit focuses on the only identifiable bug.