### PR TITLE
feat: Update enrollment section with fillable tables

### DIFF
--- a/jules-scratch/verification/verify_enrollment_tables.py
+++ b/jules-scratch/verification/verify_enrollment_tables.py
@@ -1,0 +1,16 @@
+from playwright.sync_api import Page, expect
+import re
+
+def test_enrollment_tables(page: Page):
+    """
+    This test verifies that the new enrollment tables are present in Section B.
+    """
+    # 1. Arrange: Go to the survey page.
+    page.goto("http://localhost:3000/survey.html")
+
+    # 2. Assert: Check that the new Section B heading is present.
+    section_b_heading = page.get_by_role("heading", name="Section B: ENROLMENT")
+    expect(section_b_heading).to_be_visible()
+
+    # 3. Screenshot: Capture the initial state of the tables.
+    page.screenshot(path="jules-scratch/verification/verification.png")

--- a/survey.html
+++ b/survey.html
@@ -178,47 +178,204 @@
                 <input type="number" id="nonTeachingTotal" name="nonTeachingTotal" readonly>
             </div>
 
-            <h3>ECCDE:</h3>
-            <div>
-                <label for="eccdeMale">Male *</label>
-                <input type="number" id="eccdeMale" name="eccdeMale" required>
-            </div>
-            <div>
-                <label for="eccdeFemale">Female *</label>
-                <input type="number" id="eccdeFemale" name="eccdeFemale" required>
-            </div>
-            <div>
-                <label for="eccdeTotal">Total</label>
-                <input type="number" id="eccdeTotal" name="eccdeTotal" readonly>
-            </div>
+            <h3>Pre-Primary & Primary School:</h3>
+            <table id="prePrimarySchool">
+                <thead>
+                    <tr>
+                        <th rowspan="2">CLASS</th>
+                        <th rowspan="2">NO. OF STREAM</th>
+                        <th colspan="3" style="text-align:center">SEX</th>
+                    </tr>
+                    <tr>
+                        <th>MALE</th>
+                        <th>FEMALE</th>
+                        <th>TOTAL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>NURSERY 1</td>
+                        <td><input type="number" name="prePrimary_nursery1_streams"></td>
+                        <td><input type="number" name="prePrimary_nursery1_male"></td>
+                        <td><input type="number" name="prePrimary_nursery1_female"></td>
+                        <td><input type="number" name="prePrimary_nursery1_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>NURSERY 2</td>
+                        <td><input type="number" name="prePrimary_nursery2_streams"></td>
+                        <td><input type="number" name="prePrimary_nursery2_male"></td>
+                        <td><input type="number" name="prePrimary_nursery2_female"></td>
+                        <td><input type="number" name="prePrimary_nursery2_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>KINDERGARTIN</td>
+                        <td><input type="number" name="prePrimary_kindergartin_streams"></td>
+                        <td><input type="number" name="prePrimary_kindergartin_male"></td>
+                        <td><input type="number" name="prePrimary_kindergartin_female"></td>
+                        <td><input type="number" name="prePrimary_kindergartin_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>PRIMARY 1</td>
+                        <td><input type="number" name="prePrimary_primary1_streams"></td>
+                        <td><input type="number" name="prePrimary_primary1_male"></td>
+                        <td><input type="number" name="prePrimary_primary1_female"></td>
+                        <td><input type="number" name="prePrimary_primary1_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>PRIMARY 2</td>
+                        <td><input type="number" name="prePrimary_primary2_streams"></td>
+                        <td><input type="number" name="prePrimary_primary2_male"></td>
+                        <td><input type="number" name="prePrimary_primary2_female"></td>
+                        <td><input type="number" name="prePrimary_primary2_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>PRIMARY 3</td>
+                        <td><input type="number" name="prePrimary_primary3_streams"></td>
+                        <td><input type="number" name="prePrimary_primary3_male"></td>
+                        <td><input type="number" name="prePrimary_primary3_female"></td>
+                        <td><input type="number" name="prePrimary_primary3_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>PRIMARY 4</td>
+                        <td><input type="number" name="prePrimary_primary4_streams"></td>
+                        <td><input type="number" name="prePrimary_primary4_male"></td>
+                        <td><input type="number" name="prePrimary_primary4_female"></td>
+                        <td><input type="number" name="prePrimary_primary4_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>PRIMARY 5</td>
+                        <td><input type="number" name="prePrimary_primary5_streams"></td>
+                        <td><input type="number" name="prePrimary_primary5_male"></td>
+                        <td><input type="number" name="prePrimary_primary5_female"></td>
+                        <td><input type="number" name="prePrimary_primary5_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>PRIMARY 6</td>
+                        <td><input type="number" name="prePrimary_primary6_streams"></td>
+                        <td><input type="number" name="prePrimary_primary6_male"></td>
+                        <td><input type="number" name="prePrimary_primary6_female"></td>
+                        <td><input type="number" name="prePrimary_primary6_total" readonly></td>
+                    </tr>
+                </tbody>
+            </table>
 
-            <h3>Primary:</h3>
-            <div>
-                <label for="primaryMale">Male *</label>
-                <input type="number" id="primaryMale" name="primaryMale" required>
-            </div>
-            <div>
-                <label for="primaryFemale">Female *</label>
-                <input type="number" id="primaryFemale" name="primaryFemale" required>
-            </div>
-            <div>
-                <label for="primaryTotal">Total</label>
-                <input type="number" id="primaryTotal" name="primaryTotal" readonly>
-            </div>
+            <h3>Junior Secondary School:</h3>
+            <table id="juniorSecondarySchool">
+                <thead>
+                    <tr>
+                        <th rowspan="2">CLASS</th>
+                        <th rowspan="2">NO. OF STREAM</th>
+                        <th colspan="3" style="text-align:center">SEX</th>
+                    </tr>
+                    <tr>
+                        <th>MALE</th>
+                        <th>FEMALE</th>
+                        <th>TOTAL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>JSS1</td>
+                        <td><input type="number" name="jss1_streams"></td>
+                        <td><input type="number" name="jss1_male"></td>
+                        <td><input type="number" name="jss1_female"></td>
+                        <td><input type="number" name="jss1_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>JSS2</td>
+                        <td><input type="number" name="jss2_streams"></td>
+                        <td><input type="number" name="jss2_male"></td>
+                        <td><input type="number" name="jss2_female"></td>
+                        <td><input type="number" name="jss2_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>JSS3</td>
+                        <td><input type="number" name="jss3_streams"></td>
+                        <td><input type="number" name="jss3_male"></td>
+                        <td><input type="number" name="jss3_female"></td>
+                        <td><input type="number" name="jss3_total" readonly></td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h3>Senior Secondary School:</h3>
+            <table id="seniorSecondarySchool">
+                <thead>
+                    <tr>
+                        <th rowspan="2">CLASS</th>
+                        <th rowspan="2">NO. OF STREAM</th>
+                        <th colspan="3" style="text-align:center">SEX</th>
+                    </tr>
+                    <tr>
+                        <th>MALE</th>
+                        <th>FEMALE</th>
+                        <th>TOTAL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>SSS1</td>
+                        <td><input type="number" name="sss1_streams"></td>
+                        <td><input type="number" name="sss1_male"></td>
+                        <td><input type="number" name="sss1_female"></td>
+                        <td><input type="number" name="sss1_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>SSS2</td>
+                        <td><input type="number" name="sss2_streams"></td>
+                        <td><input type="number" name="sss2_male"></td>
+                        <td><input type="number" name="sss2_female"></td>
+                        <td><input type="number" name="sss2_total" readonly></td>
+                    </tr>
+                    <tr>
+                        <td>SSS3</td>
+                        <td><input type="number" name="sss3_streams"></td>
+                        <td><input type="number" name="sss3_male"></td>
+                        <td><input type="number" name="sss3_female"></td>
+                        <td><input type="number" name="sss3_total" readonly></td>
+                    </tr>
+                </tbody>
+            </table>
 
             <h3>Special Learners:</h3>
-            <div>
-                <label for="specialMale">Male *</label>
-                <input type="number" id="specialMale" name="specialMale" required>
-            </div>
-            <div>
-                <label for="specialFemale">Female *</label>
-                <input type="number" id="specialFemale" name="specialFemale" required>
-            </div>
-            <div>
-                <label for="specialTotal">Total</label>
-                <input type="number" id="specialTotal" name="specialTotal" readonly>
-            </div>
+            <table id="specialLearners">
+                <thead>
+                    <tr>
+                        <th>CLASS (DROP DOWN)</th>
+                        <th>MALE</th>
+                        <th>FEMALE</th>
+                        <th>TOTAL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <select name="specialLearners_class_1">
+                                <option value="">Select Class</option>
+                                <option value="NURSERY 1">NURSERY 1</option>
+                                <option value="NURSERY 2">NURSERY 2</option>
+                                <option value="KINDERGARTIN">KINDERGARTIN</option>
+                                <option value="PRIMARY 1">PRIMARY 1</option>
+                                <option value="PRIMARY 2">PRIMARY 2</option>
+                                <option value="PRIMARY 3">PRIMARY 3</option>
+                                <option value="PRIMARY 4">PRIMARY 4</option>
+                                <option value="PRIMARY 5">PRIMARY 5</option>
+                                <option value="PRIMARY 6">PRIMARY 6</option>
+                                <option value="JSS1">JSS1</option>
+                                <option value="JSS2">JSS2</option>
+                                <option value="JSS3">JSS3</option>
+                                <option value="SSS1">SSS1</option>
+                                <option value="SSS2">SSS2</option>
+                                <option value="SSS3">SSS3</option>
+                            </select>
+                        </td>
+                        <td><input type="number" name="specialLearners_male_1"></td>
+                        <td><input type="number" name="specialLearners_female_1"></td>
+                        <td><input type="number" name="specialLearners_total_1" readonly></td>
+                    </tr>
+                </tbody>
+            </table>
+            <button type="button" id="addSpecialLearnerRow">Add Row</button>
 
             <h3>Total Number of Pupils in the School:</h3>
             <div>

--- a/survey.js
+++ b/survey.js
@@ -5,9 +5,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const inputsToCalculate = [
         { male: 'teachersMale', female: 'teachersFemale', total: 'teachersTotal' },
         { male: 'nonTeachingMale', female: 'nonTeachingFemale', total: 'nonTeachingTotal' },
-        { male: 'eccdeMale', female: 'eccdeFemale', total: 'eccdeTotal' },
-        { male: 'primaryMale', female: 'primaryFemale', total: 'primaryTotal' },
-        { male: 'specialMale', female: 'specialFemale', total: 'specialTotal' }
     ];
 
     inputsToCalculate.forEach(group => {
@@ -26,16 +23,91 @@ document.addEventListener('DOMContentLoaded', () => {
         femaleInput.addEventListener('input', updateTotal);
     });
 
-    function updatePupilTotals() {
-        const eccdeMale = parseInt(document.getElementById('eccdeMale').value) || 0;
-        const eccdeFemale = parseInt(document.getElementById('eccdeFemale').value) || 0;
-        const primaryMale = parseInt(document.getElementById('primaryMale').value) || 0;
-        const primaryFemale = parseInt(document.getElementById('primaryFemale').value) || 0;
-        const specialMale = parseInt(document.getElementById('specialMale').value) || 0;
-        const specialFemale = parseInt(document.getElementById('specialFemale').value) || 0;
+    function setupTableCalculation(tableId) {
+        const table = document.getElementById(tableId);
+        if (!table) return;
 
-        const totalMale = eccdeMale + primaryMale + specialMale;
-        const totalFemale = eccdeFemale + primaryFemale + specialFemale;
+        const tbody = table.querySelector('tbody');
+
+        const updateRowTotal = (row) => {
+            const maleInput = row.querySelector('input[name*="_male"]');
+            const femaleInput = row.querySelector('input[name*="_female"]');
+            const totalInput = row.querySelector('input[name*="_total"]');
+
+            if (maleInput && femaleInput && totalInput) {
+                const maleValue = parseInt(maleInput.value) || 0;
+                const femaleValue = parseInt(femaleInput.value) || 0;
+                totalInput.value = maleValue + femaleValue;
+            }
+        };
+
+        tbody.addEventListener('input', (event) => {
+            if (event.target.tagName === 'INPUT' && (event.target.name.includes('_male') || event.target.name.includes('_female'))) {
+                const row = event.target.closest('tr');
+                updateRowTotal(row);
+                updatePupilTotals();
+            }
+        });
+
+        // Initial calculation for all rows
+        tbody.querySelectorAll('tr').forEach(row => {
+            updateRowTotal(row);
+        });
+    }
+
+    setupTableCalculation('prePrimarySchool');
+    setupTableCalculation('juniorSecondarySchool');
+    setupTableCalculation('seniorSecondarySchool');
+    setupTableCalculation('specialLearners');
+
+    const addSpecialLearnerRowBtn = document.getElementById('addSpecialLearnerRow');
+    if (addSpecialLearnerRowBtn) {
+        let specialLearnerRowCounter = 2;
+        const specialLearnersTable = document.getElementById('specialLearners').querySelector('tbody');
+
+        addSpecialLearnerRowBtn.addEventListener('click', () => {
+            const newRow = document.createElement('tr');
+            newRow.innerHTML = `
+                <td>
+                    <select name="specialLearners_class_${specialLearnerRowCounter}">
+                        <option value="">Select Class</option>
+                        <option value="NURSERY 1">NURSERY 1</option>
+                        <option value="NURSERY 2">NURSERY 2</option>
+                        <option value="KINDERGARTIN">KINDERGARTIN</option>
+                        <option value="PRIMARY 1">PRIMARY 1</option>
+                        <option value="PRIMARY 2">PRIMARY 2</option>
+                        <option value="PRIMARY 3">PRIMARY 3</option>
+                        <option value="PRIMARY 4">PRIMARY 4</option>
+                        <option value="PRIMARY 5">PRIMARY 5</option>
+                        <option value="PRIMARY 6">PRIMARY 6</option>
+                        <option value="JSS1">JSS1</option>
+                        <option value="JSS2">JSS2</option>
+                        <option value="JSS3">JSS3</option>
+                        <option value="SSS1">SSS1</option>
+                        <option value="SSS2">SSS2</option>
+                        <option value="SSS3">SSS3</option>
+                    </select>
+                </td>
+                <td><input type="number" name="specialLearners_male_${specialLearnerRowCounter}"></td>
+                <td><input type="number" name="specialLearners_female_${specialLearnerRowCounter}"></td>
+                <td><input type="number" name="specialLearners_total_${specialLearnerRowCounter}" readonly></td>
+            `;
+            specialLearnersTable.appendChild(newRow);
+            specialLearnerRowCounter++;
+        });
+    }
+
+    function updatePupilTotals() {
+        let totalMale = 0;
+        let totalFemale = 0;
+
+        document.querySelectorAll('#prePrimarySchool input[name*="_male"], #juniorSecondarySchool input[name*="_male"], #seniorSecondarySchool input[name*="_male"], #specialLearners input[name*="_male"]').forEach(input => {
+            totalMale += parseInt(input.value) || 0;
+        });
+
+        document.querySelectorAll('#prePrimarySchool input[name*="_female"], #juniorSecondarySchool input[name*="_female"], #seniorSecondarySchool input[name*="_female"], #specialLearners input[name*="_female"]').forEach(input => {
+            totalFemale += parseInt(input.value) || 0;
+        });
 
         document.getElementById('totalPupilsMale').value = totalMale;
         document.getElementById('totalPupilsFemale').value = totalFemale;


### PR DESCRIPTION
Replaced the old enrollment section in the survey form with a new set of fillable tables for Pre-Primary & Primary School, Junior Secondary School, Senior Secondary School, and Special Learners.

- The new tables are based on the user's provided screenshots.
- The table headers have been updated to include a "SEX" super-header to resolve ambiguity in the user's request.
- The JavaScript has been updated to handle calculations for the new tables, including row totals and overall pupil totals.
- The teacher-to-pupil ratio calculation is preserved.
- Functionality to add new rows to the "Special Learners" table has been added.