### PR TITLE
fix(survey): Resolve JS error blocking staff total auto-sum

### DIFF
--- a/survey.html
+++ b/survey.html
@@ -278,6 +278,10 @@
             </div>
 
             <h3>Teacher/Pupils Ratio:</h3>
+            <div>
+                <label for="teacherPupilRatio">Teacher/Pupil Ratio</label>
+                <input type="text" id="teacherPupilRatio" name="teacherPupilRatio" readonly>
+            </div>
 
             <h2>Section C: STAFF</h2>
             <h3>Number of Teachers in the School:</h3>


### PR DESCRIPTION
The auto-sum functionality for teacher and non-teaching staff totals was not working due to an unrelated JavaScript error.

The 'updateTeacherPupilRatio' function was attempting to access a non-existent HTML element with the ID 'teacherPupilRatio', which caused the script to crash.

This change adds the missing input field to 'survey.html', resolving the error and allowing the existing auto-sum logic in 'survey.js' to execute correctly.