### PR TITLE
feat: Add geolocation button to survey form

### DIFF
--- a/survey.html
+++ b/survey.html
@@ -68,9 +68,15 @@
                 <input type="text" id="address" name="address" required>
             </div>
             <div>
-                <label for="geolocation">Geolocation</label>
-                <input type="text" id="geolocation" name="geolocation" required>
+                <label for="latitude">Latitude</label>
+                <input type="text" id="latitude" name="latitude" required>
             </div>
+            <div>
+                <label for="longitude">Longitude</label>
+                <input type="text" id="longitude" name="longitude" required>
+            </div>
+            <!-- The getLocation() function is defined in survey.js -->
+            <button type="button" onclick="getLocation()">Get Geolocation</button>
 
             <h2>Section B: School/Institution Data</h2>
             <h3>Pre-Primary & Primary School:</h3>


### PR DESCRIPTION
- Replaces the single "geolocation" input field with separate "latitude" and "longitude" fields.
- Adds a "Get Geolocation" button to automatically populate these fields using the browser's geolocation API.
- The `getLocation()` function already existed in `survey.js`.
- A comment was added to `survey.html` to clarify the location of the `getLocation()` function.