### PR TITLE
fix: Allow admin access to survey page and improve header

### DIFF
--- a/survey.html
+++ b/survey.html
@@ -11,14 +11,15 @@
         const user = JSON.parse(sessionStorage.getItem('user'));
         if (!user) {
             window.location.href = 'login.html';
-        } else if (user.role !== 'enumerator') {
+        } else if (user.role !== 'enumerator' && user.role !== 'admin') {
             window.location.href = 'index.html';
         }
     </script>
     <header>
         <img src="surveylogo.jpeg" alt="Lagos State Logo">
         <h1>Data Entry</h1>
-        <button id="logout-button" style="float: right; margin: 10px; padding: 8px 12px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Logout</button>
+        <a id="back-to-home" href="index.html" style="display: none;">← Back to Home</a>
+        <button id="logout-button" style="display: none; float: right; margin: 10px; padding: 8px 12px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Logout</button>
     </header>
     <main>
         <form id="surveyForm">

--- a/survey.js
+++ b/survey.js
@@ -22,6 +22,18 @@ const lgaWardData = {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+    const user = JSON.parse(sessionStorage.getItem('user'));
+    const backToHome = document.getElementById('back-to-home');
+    const logoutButton = document.getElementById('logout-button');
+
+    if (user.role === 'admin') {
+        if (backToHome) backToHome.style.display = 'inline';
+        if (logoutButton) logoutButton.style.display = 'none';
+    } else if (user.role === 'enumerator') {
+        if (backToHome) backToHome.style.display = 'none';
+        if (logoutButton) logoutButton.style.display = 'inline-block';
+    }
+
     const ownership = document.getElementById('ownership');
     const privateSpecifics = document.getElementById('private-specifics');
     const privateType = document.getElementById('private-type');


### PR DESCRIPTION
This commit fixes a bug where admin users were redirected from the survey page. It also improves the user experience by dynamically showing header links based on the user's role.

Key changes:
- Updated the access control script in `survey.html` to allow admin users.
- Modified `survey.html` to include both a "Back to Home" link and a "Logout" button.
- Added logic to `survey.js` to dynamically display the "Back to Home" link for admins and the "Logout" button for enumerators.