### PR TITLE
Fixes a JavaScript error on the survey page that was preventing the c…

### DIFF
--- a/survey.js
+++ b/survey.js
@@ -252,7 +252,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    const logoutButton = document.getElementById('logout-button');
     if (logoutButton) {
         logoutButton.addEventListener('click', () => {
             sessionStorage.removeItem('loggedIn');


### PR DESCRIPTION
…orrect visibility logic for the "Logout" and "Back to Home" buttons from running.

A duplicate declaration of the 'logoutButton' variable was causing a syntax error. Removing the duplicate declaration resolves the issue.

As per user confirmation, the "Logout" button is now correctly hidden for admin users, and the "Back to Home" button is displayed. For enumerator users, the "Logout" button is displayed, and the "Back to Home" button is hidden.