### PR TITLE
Fix: User list not displaying due to auth error

### DIFF
--- a/users.js
+++ b/users.js
@@ -1,11 +1,33 @@
 document.addEventListener('DOMContentLoaded', () => {
     const usersTable = document.getElementById('users-table').getElementsByTagName('tbody')[0];
     const addUserBtn = document.getElementById('add-user-btn');
+    const user = JSON.parse(sessionStorage.getItem('user'));
+    const userId = user ? user.id : null;
+
+    if (!userId) {
+        alert('You must be logged in as an admin to view this page.');
+        window.location.href = 'login.html';
+        return;
+    }
 
     // Fetch users and populate the table
-    fetch('/api/users')
-        .then(response => response.json())
+    fetch('/api/users', {
+        headers: {
+            'x-user-id': userId
+        }
+    })
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(err => { throw new Error(err.message || 'Failed to fetch users'); });
+            }
+            return response.json();
+        })
         .then(users => {
+            if (!Array.isArray(users)) {
+                console.error('Error: Expected an array of users, but received:', users);
+                alert('There was an error fetching the list of users.');
+                return;
+            }
             users.forEach(user => {
                 const row = usersTable.insertRow();
                 row.innerHTML = `
@@ -20,7 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 `;
             });
         })
-        .catch(error => console.error('Error fetching users:', error));
+        .catch(error => {
+            console.error('Error fetching users:', error);
+            alert(error.message);
+        });
 
     // "Add User" button event listener
     addUserBtn.addEventListener('click', () => {
@@ -35,21 +60,34 @@ function editUser(userId) {
 
 // Delete user function
 function deleteUser(userId) {
+    const user = JSON.parse(sessionStorage.getItem('user'));
+    const actorId = user ? user.id : null;
+
+    if (!actorId) {
+        alert('Authentication error. Please log in again.');
+        return;
+    }
+
     if (confirm('Are you sure you want to delete this user?')) {
         fetch(`/api/user/${userId}`, {
-            method: 'DELETE'
+            method: 'DELETE',
+            headers: {
+                'x-user-id': actorId
+            }
         })
         .then(response => {
             if (response.ok) {
                 alert('User deleted successfully!');
                 window.location.reload();
             } else {
-                alert('Failed to delete user.');
+                response.json().then(err => {
+                    alert(`Failed to delete user: ${err.message}`);
+                });
             }
         })
         .catch(error => {
             console.error('Error deleting user:', error);
-            alert('Failed to delete user.');
+            alert('An error occurred while trying to delete the user.');
         });
     }
 }


### PR DESCRIPTION
The user list page was crashing with a `TypeError` because the API request to `/api/users` was failing silently. The request was missing the `x-user-id` header required for authentication by the `isAdmin` middleware.

This change updates `users.js` to:
- Retrieve the logged-in user's ID from `sessionStorage`.
- Send the user ID in the `x-user-id` header with the fetch request.
- Add robust error handling to gracefully handle authorization failures or other API errors, preventing the application from crashing and providing clear feedback to the user.