### PR TITLE
Fix: Correct syntax errors in server.js to allow server to start

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,9 +49,9 @@ app.get('/science', (req, res) => {
 
 app.get('/science-report', (req, res) => {
     res.sendFile(__dirname + '/science-report.html');
+});
 app.get('/private-form', (req, res) => {
     res.sendFile(__dirname + '/private_form.html');
-
 });
 
 // MongoDB Connection
@@ -290,6 +290,10 @@ app.post('/api/science', isEnumerator, (req, res) => {
             });
     } catch (error) {
         console.error('Error in /api/science route:', error);
+        res.status(500).json('Server error');
+    }
+});
+
 app.post('/api/private-survey', isEnumerator, (req, res) => {
     try {
         const surveyData = req.body;
@@ -323,18 +327,10 @@ app.get('/api/science-reports', async (req, res) => {
 app.get('/api/data', async (req, res) => {
     try {
         const surveys = await Survey.find();
+        const privateSurveys = await PrivateSurvey.find();
         const scienceForms = await Science.find();
 
-        if (surveys.length === 0 && scienceForms.length === 0) {
-            return res.json({ noData: true });
-        }
-
-app.get('/api/data', async (req, res) => {
-    try {
-        const surveys = await Survey.find();
-        const privateSurveys = await PrivateSurvey.find();
-
-        if (surveys.length === 0 && privateSurveys.length === 0) {
+        if (surveys.length === 0 && privateSurveys.length === 0 && scienceForms.length === 0) {
             return res.json({ noData: true });
         }
 


### PR DESCRIPTION
This commit addresses a critical syntax error that prevented the Node.js server from starting. The error was caused by a missing closing brace in a route handler and a duplicated route definition.

- Added a closing brace to the `/api/science` POST route.
- Merged a duplicated `/api/data` route definition into a single, correct implementation.
- Cleaned up minor formatting issues related to the syntax errors.