### PR TITLE
feat: Add Senior Secondary School (SSS) form

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -56,6 +56,11 @@
                 <a href="/jss">Go to Form</a>
 
             </div>
+            <div class="card">
+                <h3>SSS Form</h3>
+                <p>Annual census form for Senior Secondary Schools.</p>
+                <a href="/sss">Go to Form</a>
+            </div>
         </div>
     </main>
     <script src="forms.js"></script>

--- a/models/sss.js
+++ b/models/sss.js
@@ -1,0 +1,326 @@
+const mongoose = require('mongoose');
+
+const sssSchema = new mongoose.Schema({
+    schoolCode: String,
+    schoolCoordinates: {
+        elevation: Number,
+        latitudeNorth: String,
+        longitudeEast: String,
+    },
+    schoolIdentification: {
+        schoolName: String,
+        numberAndStreet: String,
+        villageOrTown: String,
+        ward: String,
+        lga: String,
+        state: String,
+        schoolTelephone: String,
+        emailAddress: String,
+    },
+    schoolCharacteristics: {
+        yearOfEstablishment: Number,
+        location: String, // Urban, Rural
+        levelsOfEducation: String, // Senior Secondary only, Junior and Senior Secondary
+        typeOfSchool: String, // Regular, Islamiyya integrated
+        shifts: String, // Yes, No
+        sharedFacilities: {
+            shares: String, // Yes, No
+            numberOfSchools: Number,
+        },
+        multiGradeTeaching: String, // Yes, No
+        distanceFromCatchment: Number,
+        distanceFromLGA: Number,
+        studentsFurtherThan3km: Number,
+        boardingStudents: {
+            male: Number,
+            female: Number,
+        },
+        sdpLastYear: String, // Yes, No
+        sbmcLastYear: String, // Yes, No
+        ptaLastYear: String, // Yes, No
+        lastInspectionDate: Date,
+        numberOfInspections: Number,
+        lastInspectionAuthority: String, // Federal, State, LGEA
+        conditionalCashTransferBeneficiaries: Number,
+        grantsLastYear: String, // Yes, No
+        securityGuard: String, // Yes, No
+        ownership: String, // Federal, State, LGEA, Community
+    },
+    enrolment: {
+        studentsWithBirthCertificatesSSS1: Number,
+        newEntrantsSSS1: Number,
+        seniorSecondaryEnrolment: {
+            ss1: { streams: Number, multigradeStreams: Number, below15: { male: Number, female: Number }, age15: { male: Number, female: Number }, age16: { male: Number, female: Number }, age17: { male: Number, female: Number }, above17: { male: Number, female: Number } },
+            ss2: { streams: Number, multigradeStreams: Number, below15: { male: Number, female: Number }, age15: { male: Number, female: Number }, age16: { male: Number, female: Number }, age17: { male: Number, female: Number }, above17: { male: Number, female: Number } },
+            ss3: { streams: Number, multigradeStreams: Number, below15: { male: Number, female: Number }, age15: { male: Number, female: Number }, age16: { male: Number, female: Number }, age17: { male: Number, female: Number }, above17: { male: Number, female: Number }, completedPreviousYear: { male: Number, female: Number } },
+        },
+        studentFlow: {
+            ss1: { dropout: { male: Number, female: Number }, transferIn: { male: Number, female: Number }, transferOut: { male: Number, female: Number }, repeaters: { male: Number, female: Number }, promoted: { male: Number, female: Number } },
+            ss2: { dropout: { male: Number, female: Number }, transferIn: { male: Number, female: Number }, transferOut: { male: Number, female: Number }, repeaters: { male: Number, female: Number }, promoted: { male: Number, female: Number } },
+            ss3: { dropout: { male: Number, female: Number }, transferIn: { male: Number, female: Number }, transferOut: { male: Number, female: Number }, repeaters: { male: Number, female: Number }, promoted: { male: Number, female: Number } },
+        },
+        studentsWithSpecialNeeds: {
+            ss1: { blind: { male: Number, female: Number }, hearingImpaired: { male: Number, female: Number }, physicallyChallenged: { male: Number, female: Number }, mentallyChallenged: { male: Number, female: Number }, albinism: { male: Number, female: Number }, autism: { male: Number, female: Number } },
+            ss2: { blind: { male: Number, female: Number }, hearingImpaired: { male: Number, female: Number }, physicallyChallenged: { male: Number, female: Number }, mentallyChallenged: { male: Number, female: Number }, albinism: { male: Number, female: Number }, autism: { male: Number, female: Number } },
+            ss3: { blind: { male: Number, female: Number }, hearingImpaired: { male: Number, female: Number }, physicallyChallenged: { male: Number, female: Number }, mentallyChallenged: { male: Number, female: Number }, albinism: { male: Number, female: Number }, autism: { male: Number, female: Number } },
+        },
+        ssceExams: {
+            waec: {
+                registered: { male: Number, female: Number, total: Number },
+                sat: { male: Number, female: Number, total: Number },
+                passed: { male: Number, female: Number, total: Number },
+            },
+            neco: {
+                registered: { male: Number, female: Number, total: Number },
+                sat: { male: Number, female: Number, total: Number },
+                passed: { male: Number, female: Number, total: Number },
+            },
+        },
+    },
+    staff: {
+        nonTeaching: { male: Number, female: Number, total: Number },
+        teaching: { male: Number, female: Number, total: Number },
+        staffInfo: [{
+            staffFileNo: String,
+            name: String,
+            gender: String, // M, F
+            type: String, // Principal, Vice principal, Teacher, Other non-teaching staff
+            sourceOfSalary: String, // Federal Government - FTS, State Government - On this school's payroll, State Government - On another school's payroll, Other, No salary
+            yearOfBirth: Number,
+            yearOfFirstAppointment: Number,
+            yearOfPresentAppointment: Number,
+            yearOfPosting: Number,
+            gradeLevelStep: String,
+            present: String, // Present or temporarily absent, Absent for more than 1 month - Maternity / Paternity leave, Absent for more than 1 month - Sick leave, Absent for more than 1 month - Training, Absent for more than 1 month - Unauthorised
+            academicQualification: String, // Below SSCE, SSCE/WASC, ND, NCE, Degree / HND / Graduate, Masters degree, PhD
+            teachingQualification: String, // NCE, PGDE, B.Ed. or equivalent, M.Ed. or equivalent, Grade II or equivalent, None
+            subjectOfQualification: String,
+            mainSubjectTaught: String,
+            teachingType: String, // Full-time, Part-time
+            teachesJuniorSecondary: Boolean,
+            trainingsLast12Months: Number,
+        }],
+    },
+    classrooms: {
+        numberOfClassrooms: Number,
+        classesHeldOutside: {
+            held: String, // Yes, No
+            number: Number,
+        },
+        classroomInfo: [{
+            yearOfConstruction: Number,
+            presentCondition: String, // Good, Needs minor repairs, Needs major repairs, Under construction, Unusable
+            length: Number,
+            width: Number,
+            floorMaterial: String, // Mud/Earth, Concrete, Wood, Tile/Terrazzo
+            wallMaterial: String, // Mud, Cement/Concrete, Wood/Bamboo, Burnt bricks, Iron sheets, Stone, No walls / dwarf walls
+            roofMaterial: String, // Mud, Cement/Concrete, Wood/Bamboo, Ceramic tiles, Iron sheets, Asbestos, No roof
+            seating: String, // Yes, No
+            goodBlackboard: String, // Yes, No
+        }],
+        otherRooms: {
+            staffRooms: Number,
+            office: Number,
+            library: Number,
+            laboratories: Number,
+            storeRoom: Number,
+            others: Number,
+        },
+    },
+    facilities: {
+        safeDrinkingWater: [String], // Pipe- borne Water, Borehole, Well, Other, No Source of Safe Water
+        availableFacilities: {
+            toilets: { useable: Number, notUseable: Number },
+            computers: { useable: Number, notUseable: Number },
+            waterSources: { useable: Number, notUseable: Number },
+            laboratories: { useable: Number, notUseable: Number },
+            classrooms: { useable: Number, notUseable: Number },
+            library: { useable: Number, notUseable: Number },
+            readingCorner: { useable: Number, notUseable: Number },
+            playgrounds: { useable: Number, notUseable: Number },
+            washHandFacility: { useable: Number, notUseable: Number },
+            others: { useable: Number, notUseable: Number },
+        },
+        sharedFacilities: {
+            toilets: Boolean,
+            classrooms: Boolean,
+            computers: Boolean,
+            library: Boolean,
+            waterSources: Boolean,
+            playgrounds: Boolean,
+            laboratories: Boolean,
+            washHandFacility: Boolean,
+            others: Boolean,
+        },
+        toilets: {
+            studentOnly: {
+                pit: { male: Number, female: Number, mixed: Number },
+                bucket: { male: Number, female: Number, mixed: Number },
+                waterFlush: { male: Number, female: Number, mixed: Number },
+                others: { male: Number, female: Number, mixed: Number },
+            },
+            teacherOnly: {
+                pit: { male: Number, female: Number, mixed: Number },
+                bucket: { male: Number, female: Number, mixed: Number },
+                waterFlush: { male: Number, female: Number, mixed: Number },
+                others: { male: Number, female: Number, mixed: Number },
+            },
+            studentAndTeacher: {
+                pit: { male: Number, female: Number, mixed: Number },
+                bucket: { male: Number, female: Number, mixed: Number },
+                waterFlush: { male: Number, female: Number, mixed: Number },
+                others: { male: Number, female: Number, mixed: Number },
+            },
+        },
+        powerSources: [String], // PHCN/NEPA, Generator, Solar, No source of Power
+        healthFacility: {
+            type: [String], // Health Clinic/Sick Bay, First Aid Kit, No Health facility
+            hasPersonnel: String, // Yes, No
+        },
+        safetyFacilities: [String], // perimeter fence, school gate, Security guards, Security camera
+        agriculturalFacilities: [String], // Poultry Farm, Fish Pond, Piggery Pen, School Farm, Others
+        additionalClassInfo: {
+            ss1: { oneSeater: Number, twoSeater: Number, threeSeater: Number },
+            ss2: { oneSeater: Number, twoSeater: Number, threeSeater: Number },
+            ss3: { oneSeater: Number, twoSeater: Number, threeSeater: Number },
+        },
+    },
+    subjectEnrolment: [{
+        subject: String,
+        ss1: { male: Number, female: Number },
+        ss2: { male: Number, female: Number },
+        ss3: { male: Number, female: Number },
+    }],
+    studentTeacherBook: {
+        textbooksByGovt: {
+            english: { sss1: Number, sss2: Number, sss3: Number },
+            mathematics: { sss1: Number, sss2: Number, sss3: Number },
+            civicEducation: { sss1: Number, sss2: Number, sss3: Number },
+            tradeSubjects: { sss1: Number, sss2: Number, sss3: Number },
+        },
+        textbooksByOther: {
+            english: { sss1: Number, sss2: Number, sss3: Number },
+            mathematics: { sss1: Number, sss2: Number, sss3: Number },
+            civicEducation: { sss1: Number, sss2: Number, sss3: Number },
+            tradeSubjects: { sss1: Number, sss2: Number, sss3: Number },
+        },
+        teacherTextbooksByGovt: {
+            english: { sss1: Number, sss2: Number, sss3: Number },
+            mathematics: { sss1: Number, sss2: Number, sss3: Number },
+            civicEducation: { sss1: Number, sss2: Number, sss3: Number },
+            tradeSubjects: { sss1: Number, sss2: Number, sss3: Number },
+        },
+        teacherTextbooksByOther: {
+            english: { sss1: Number, sss2: Number, sss3: Number },
+            mathematics: { sss1: Number, sss2: Number, sss3: Number },
+            civicEducation: { sss1: Number, sss2: Number, sss3: Number },
+            tradeSubjects: { sss1: Number, sss2: Number, sss3: Number },
+        },
+        teacherGuidesByGovt: {
+            english: { sss1: Number, sss2: Number, sss3: Number },
+            mathematics: { sss1: Number, sss2: Number, sss3: Number },
+            civicEducation: { sss1: Number, sss2: Number, sss3: Number },
+            tradeSubjects: { sss1: Number, sss2: Number, sss3: Number },
+        },
+        teacherGuidesByOther: {
+            english: { sss1: Number, sss2: Number, sss3: Number },
+            mathematics: { sss1: Number, sss2: Number, sss3: Number },
+            civicEducation: { sss1: Number, sss2: Number, sss3: Number },
+            tradeSubjects: { sss1: Number, sss2: Number, sss3: Number },
+        },
+    },
+    teacherQualificationByLevel: {
+        sss: {
+            phd: { male: Number, female: Number, total: Number },
+            mastersWithTeaching: { male: Number, female: Number, total: Number },
+            mastersWithoutTeaching: { male: Number, female: Number, total: Number },
+            degreeWithTeaching: { male: Number, female: Number, total: Number },
+            degreeWithoutTeaching: { male: Number, female: Number, total: Number },
+            hndWithTeaching: { male: Number, female: Number, total: Number },
+            hndWithoutTeaching: { male: Number, female: Number, total: Number },
+            nce: { male: Number, female: Number, total: Number },
+            ond: { male: Number, female: Number, total: Number },
+            gradeII: { male: Number, female: Number, total: Number },
+            ssce: { male: Number, female: Number, total: Number },
+            belowSSCE: { male: Number, female: Number, total: Number },
+            others: { male: Number, female: Number, total: Number },
+        },
+    },
+    schoolWellBeing: {
+        hasRules: String, // YES, NO
+        rulesCover: {
+            physicalSafety: {
+                bullying: String, // YES, NO
+                physicalViolence: String, // YES, NO
+                corporalPunishment: String, // YES, NO
+                hasSecurityPersonnel: String, // YES, NO
+                hasPerimeterFence: String, // YES, NO
+                hasBeenAttacked: String, // YES, NO
+                timesAttackedLast3Years: Number,
+                others: String,
+            },
+            stigmaAndDiscrimination: {
+                learnersHIV: String, // YES, NO
+                learnersEthnicity: String, // YES, NO
+                learnersHarassed: String, // YES, NO
+                staffHIV: String, // YES, NO
+                staffEthnicity: String, // YES, NO
+                staffHarassed: String, // YES, NO
+            },
+            grievanceProcedures: String, // YES, NO
+        },
+        communicationOfRules: {
+            toLearners: String, // YES, NO
+            toTeachers: String, // YES, NO
+            toParents: String, // YES, NO
+        },
+        wellBeingEducation: {
+            receivedLifeSkills: String, // YES, NO
+            topicsCovered: {
+                genericLifeSkills: String, // YES, NO
+                reproductiveHealth: String, // YES, NO
+                hivPrevention: String, // YES, NO
+                epidemics: String, // YES, NO
+                pandemics: String, // YES, NO
+            },
+        },
+        learnersReceivedSWB: { male: Number, female: Number },
+        parentOrientation: {
+            timesOrganized: Number,
+            fora: [String], // PTA, Open Day, Special Session(s)
+        },
+        lastOrientationDate: Date,
+        teacherTraining: {
+            receivedFormalTraining: { male: Number, female: Number },
+            taughtRelatedTopics: { male: Number, female: Number },
+        },
+    },
+    undertaking: {
+        principal: {
+            name: String,
+            telephone: String,
+            signature: String,
+            date: Date,
+        },
+        sbmcChairperson: {
+            name: String,
+            position: String,
+            telephone: String,
+            signature: String,
+            date: Date,
+        },
+        supervisor: {
+            name: String,
+            position: String,
+            telephone: String,
+            signature: String,
+            date: Date,
+        },
+    },
+    createdAt: {
+        type: Date,
+        default: Date.now
+    }
+});
+
+module.exports = mongoose.model('Sss', sssSchema);

--- a/server.js
+++ b/server.js
@@ -63,6 +63,10 @@ app.get('/jss', (req, res) => {
     res.sendFile(__dirname + '/jss.html');
 });
 
+app.get('/sss', (req, res) => {
+    res.sendFile(__dirname + '/sss.html');
+});
+
 // MongoDB Connection
 const dbURI = process.env.DATABASE_URL;
 if (!dbURI) {
@@ -82,6 +86,7 @@ const Science = require('./models/Science');
 const PrivateSurvey = require('./models/PrivateSurvey');
 const Eccde = require('./models/Eccde');
 const Jss = require('./models/jss');
+const Sss = require('./models/sss');
 
 const User = require('./models/User');
 const AuditLog = require('./models/AuditLog');
@@ -333,6 +338,27 @@ app.post('/api/jss', isEnumerator, (req, res) => {
     }
 });
 
+app.post('/api/sss', isEnumerator, (req, res) => {
+    try {
+        const sssData = req.body;
+        const newSss = new Sss(sssData);
+        newSss.save()
+            .then(sss => {
+                const actorId = req.headers['x-user-id'];
+                logAction(actorId, `submitted SSS form for school ${sss.schoolIdentification.schoolName}`);
+                console.log('SSS form saved successfully:', sss);
+                res.json(sss);
+            })
+            .catch(err => {
+                console.error('Error saving SSS form:', err);
+                res.status(400).json({ message: 'Error: ' + err, error: err });
+            });
+    } catch (error) {
+        console.error('Error in /api/sss route:', error);
+        res.status(500).json('Server error');
+    }
+});
+
 app.post('/api/private-survey', isEnumerator, (req, res) => {
     try {
         const surveyData = req.body;
@@ -402,8 +428,9 @@ app.get('/api/data', async (req, res) => {
         const privateSurveys = await PrivateSurvey.find();
         const eccdeForms = await Eccde.find();
         const jssForms = await Jss.find();
+        const sssForms = await Sss.find();
 
-        if (surveys.length === 0 && scienceForms.length === 0 && privateSurveys.length === 0 && eccdeForms.length === 0 && jssForms.length === 0) {
+        if (surveys.length === 0 && scienceForms.length === 0 && privateSurveys.length === 0 && eccdeForms.length === 0 && jssForms.length === 0 && sssForms.length === 0) {
             return res.json({ noData: true });
         }
 
@@ -428,6 +455,13 @@ app.get('/api/data', async (req, res) => {
                 }
             });
         });
+        sssForms.forEach(s => {
+            s.staff?.staffInfo?.forEach(staff => {
+                if (staff.academicQualification) {
+                    qualificationCounts[staff.academicQualification] = (qualificationCounts[staff.academicQualification] || 0) + 1;
+                }
+            });
+        });
 
         const electricityCounts = {};
         surveys.forEach(s => {
@@ -443,6 +477,13 @@ app.get('/api/data', async (req, res) => {
             });
         });
         jssForms.forEach(s => {
+            s.facilities?.powerSources?.forEach(source => {
+                if (source) {
+                    electricityCounts[source] = (electricityCounts[source] || 0) + 1;
+                }
+            });
+        });
+        sssForms.forEach(s => {
             s.facilities?.powerSources?.forEach(source => {
                 if (source) {
                     electricityCounts[source] = (electricityCounts[source] || 0) + 1;
@@ -479,6 +520,16 @@ app.get('/api/data', async (req, res) => {
                 }
             });
         });
+        sssForms.forEach(s => {
+            s.staff?.staffInfo?.forEach(staff => {
+                const gender = staff.gender?.toUpperCase();
+                if (gender === 'M') {
+                    genderCounts.Male++;
+                } else if (gender === 'F') {
+                    genderCounts.Female++;
+                }
+            });
+        });
 
         const schoolTypeCounts = {};
         scienceForms.forEach(s => {
@@ -488,6 +539,12 @@ app.get('/api/data', async (req, res) => {
             }
         });
         jssForms.forEach(s => {
+            const type = s.schoolCharacteristics?.typeOfSchool;
+            if (type) {
+                schoolTypeCounts[type] = (schoolTypeCounts[type] || 0) + 1;
+            }
+        });
+        sssForms.forEach(s => {
             const type = s.schoolCharacteristics?.typeOfSchool;
             if (type) {
                 schoolTypeCounts[type] = (schoolTypeCounts[type] || 0) + 1;
@@ -507,6 +564,12 @@ app.get('/api/data', async (req, res) => {
                 locationCounts[location] = (locationCounts[location] || 0) + 1;
             }
         });
+        sssForms.forEach(s => {
+            const location = s.schoolCharacteristics?.location;
+            if(location) {
+                locationCounts[location] = (locationCounts[location] || 0) + 1;
+            }
+        });
 
         let totalStudents = 0;
         scienceForms.forEach(s => {
@@ -521,6 +584,19 @@ app.get('/api/data', async (req, res) => {
                     totalStudents += (enrolment?.above14?.male || 0) + (enrolment?.above14?.female || 0);
                 }
             }
+            const sssEnrolment = s.enrolment?.seniorSecondaryEnrolment;
+            if (sssEnrolment) {
+                for (const level in sssEnrolment) {
+                    const enrolment = sssEnrolment[level];
+                    totalStudents += (enrolment?.below15?.male || 0) + (enrolment?.below15?.female || 0);
+                    totalStudents += (enrolment?.age15?.male || 0) + (enrolment?.age15?.female || 0);
+                    totalStudents += (enrolment?.age16?.male || 0) + (enrolment?.age16?.female || 0);
+                    totalStudents += (enrolment?.age17?.male || 0) + (enrolment?.age17?.female || 0);
+                    totalStudents += (enrolment?.above17?.male || 0) + (enrolment?.above17?.female || 0);
+                }
+            }
+        });
+        sssForms.forEach(s => {
             const sssEnrolment = s.enrolment?.seniorSecondaryEnrolment;
             if (sssEnrolment) {
                 for (const level in sssEnrolment) {

--- a/sss.html
+++ b/sss.html
@@ -1,0 +1,1214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SSS School Census Form</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="survey.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <ul>
+                <li><a href="/">Dashboard</a></li>
+                <li><a href="/users">Users</a></li>
+                <li><a href="/profile">Profile</a></li>
+                <li><a href="/survey">Survey</a></li>
+                <li><a href="/reports">Reports</a></li>
+                <li><a href="/science-report">Science Reports</a></li>
+                <li><a href="/audit-log">Audit Log</a></li>
+                <li><a href="/forms">School Census Forms</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <h1>SSS School Census Form</h1>
+        <form id="sss-form">
+            <p>For Principal Only: Search for your school using search school option in the NEMIS ASC PORTAL. If school is not found, prompt the LEMIS or SEMIS Officer to add school.</p>
+
+            <fieldset>
+                <legend>School Location</legend>
+                <label for="schoolCode">School Code</label>
+                <input type="text" id="schoolCode" name="schoolCode">
+
+                <label for="elevation">Elevation (Meter)</label>
+                <input type="number" id="elevation" name="schoolCoordinates.elevation">
+
+                <label for="latitude">Latitude North</label>
+                <input type="text" id="latitude" name="schoolCoordinates.latitudeNorth">
+
+                <label for="longitude">Longitude East</label>
+                <input type="text" id="longitude" name="schoolCoordinates.longitudeEast">
+            </fieldset>
+
+            <fieldset>
+                <legend>A. School Identification</legend>
+                <label for="schoolName">A.1 School Name</label>
+                <input type="text" id="schoolName" name="schoolIdentification.schoolName">
+
+                <label for="street">A.2 Number and Street name</label>
+                <input type="text" id="street" name="schoolIdentification.numberAndStreet">
+
+                <label for="village">A.3 Name of Village or Town</label>
+                <input type="text" id="village" name="schoolIdentification.villageOrTown">
+
+                <label for="ward">A.4 Ward</label>
+                <input type="text" id="ward" name="schoolIdentification.ward">
+
+                <label for="lga">A.5 LGA</label>
+                <input type="text" id="lga" name="schoolIdentification.lga">
+
+                <label for="state">A.6 State</label>
+                <input type="text" id="state" name="schoolIdentification.state">
+
+                <label for="schoolTelephone">A.7 School Telephone/ principal’s GSM number</label>
+                <input type="text" id="schoolTelephone" name="schoolIdentification.schoolTelephone">
+
+                <label for="email">A.8 E-mail Address</label>
+                <input type="email" id="email" name="schoolIdentification.emailAddress">
+            </fieldset>
+
+            <fieldset>
+                <legend>B. School Characteristics</legend>
+                <label for="yearOfEstablishment">B.1 Year of establishment</label>
+                <input type="number" id="yearOfEstablishment" name="schoolCharacteristics.yearOfEstablishment">
+
+                <label>B.2 Location</label>
+                <input type="radio" id="urban" name="schoolCharacteristics.location" value="Urban">
+                <label for="urban">Urban</label>
+                <input type="radio" id="rural" name="schoolCharacteristics.location" value="Rural">
+                <label for="rural">Rural</label>
+
+                <label>B.3 Levels of education offered</label>
+                <input type="radio" id="sssOnly" name="schoolCharacteristics.levelsOfEducation" value="Senior Secondary only">
+                <label for="sssOnly">Senior Secondary only</label>
+                <input type="radio" id="jssAndSss" name="schoolCharacteristics.levelsOfEducation" value="Junior and Senior Secondary">
+                <label for="jssAndSss">Junior and Senior Secondary</label>
+
+                <label>B.4 Type of school</label>
+                <input type="radio" id="regular" name="schoolCharacteristics.typeOfSchool" value="Regular">
+                <label for="regular">Regular</label>
+                <input type="radio" id="islamiyya" name="schoolCharacteristics.typeOfSchool" value="Islamiyya integrated">
+                <label for="islamiyya">Islamiyya integrated</label>
+
+                <label>B.5 Shifts: Does the School operate shift system?</label>
+                <input type="radio" id="shiftsYes" name="schoolCharacteristics.shifts" value="Yes">
+                <label for="shiftsYes">Yes</label>
+                <input type="radio" id="shiftsNo" name="schoolCharacteristics.shifts" value="No">
+                <label for="shiftsNo">No</label>
+
+                <label>B.6 Shared facilities</label>
+                <input type="radio" id="sharedFacilitiesYes" name="schoolCharacteristics.sharedFacilities.shares" value="Yes">
+                <label for="sharedFacilitiesYes">Yes</label>
+                <input type="radio" id="sharedFacilitiesNo" name="schoolCharacteristics.sharedFacilities.shares" value="No">
+                <label for="sharedFacilitiesNo">No</label>
+                <label for="numberOfSchoolsSharing">If Yes. How many Schools are sharing facilities:</label>
+                <input type="number" id="numberOfSchoolsSharing" name="schoolCharacteristics.sharedFacilities.numberOfSchools">
+
+                <label>B.7 Multi-grade teaching</label>
+                <input type="radio" id="multiGradeYes" name="schoolCharacteristics.multiGradeTeaching" value="Yes">
+                <label for="multiGradeYes">Yes</label>
+                <input type="radio" id="multiGradeNo" name="schoolCharacteristics.multiGradeTeaching" value="No">
+                <label for="multiGradeNo">No</label>
+
+                <label for="distanceFromCatchment">B.8 School: Average Distance from Catchment Communities/areas (kilometres)</label>
+                <input type="number" id="distanceFromCatchment" name="schoolCharacteristics.distanceFromCatchment">
+
+                <label for="distanceFromLGA">B.9 School: Distance from LGA (kilometres)</label>
+                <input type="number" id="distanceFromLGA" name="schoolCharacteristics.distanceFromLGA">
+
+                <label for="studentsFurtherThan3km">B.10 Students: Distance from School (How many students live further than 3km from the school?)</label>
+                <input type="number" id="studentsFurtherThan3km" name="schoolCharacteristics.studentsFurtherThan3km">
+
+                <label>B.11 Students: Boarding</label>
+                <label for="boardingMale">Male</label>
+                <input type="number" id="boardingMale" name="schoolCharacteristics.boardingStudents.male">
+                <label for="boardingFemale">Female</label>
+                <input type="number" id="boardingFemale" name="schoolCharacteristics.boardingStudents.female">
+
+                <label>B.12 School Development Plan (SDP)</label>
+                <input type="radio" id="sdpYes" name="schoolCharacteristics.sdpLastYear" value="Yes">
+                <label for="sdpYes">Yes</label>
+                <input type="radio" id="sdpNo" name="schoolCharacteristics.sdpLastYear" value="No">
+                <label for="sdpNo">No</label>
+
+                <label>B.13 School Based Management Committee (SBMC)</label>
+                <input type="radio" id="sbmcYes" name="schoolCharacteristics.sbmcLastYear" value="Yes">
+                <label for="sbmcYes">Yes</label>
+                <input type="radio" id="sbmcNo" name="schoolCharacteristics.sbmcLastYear" value="No">
+                <label for="sbmcNo">No</label>
+
+                <label>B.14 Parent-Teacher Association (PTA) / Parents' Forum (PF)</label>
+                <input type="radio" id="ptaYes" name="schoolCharacteristics.ptaLastYear" value="Yes">
+                <label for="ptaYes">Yes</label>
+                <input type="radio" id="ptaNo" name="schoolCharacteristics.ptaLastYear" value="No">
+                <label for="ptaNo">No</label>
+
+                <label for="lastInspectionDate">B.15 Date of Last Inspection Visit</label>
+                <input type="date" id="lastInspectionDate" name="schoolCharacteristics.lastInspectionDate">
+                <label for="numberOfInspections">Number of inspection Visit in last academic year</label>
+                <input type="number" id="numberOfInspections" name="schoolCharacteristics.numberOfInspections">
+
+                <label>B.16 Authority of Last Inspection</label>
+                <input type="radio" id="federal" name="schoolCharacteristics.lastInspectionAuthority" value="Federal">
+                <label for="federal">Federal</label>
+                <input type="radio" id="stateInsp" name="schoolCharacteristics.lastInspectionAuthority" value="State">
+                <label for="stateInsp">State</label>
+                <input type="radio" id="lgeaInsp" name="schoolCharacteristics.lastInspectionAuthority" value="LGEA">
+                <label for="lgeaInsp">LGEA</label>
+
+                <label for="conditionalCashTransfer">B.17 Conditional Cash Transfer</label>
+                <input type="number" id="conditionalCashTransfer" name="schoolCharacteristics.conditionalCashTransferBeneficiaries">
+
+                <label>B.18 School Grants</label>
+                <input type="radio" id="grantsYes" name="schoolCharacteristics.grantsLastYear" value="Yes">
+                <label for="grantsYes">Yes</label>
+                <input type="radio" id="grantsNo" name="schoolCharacteristics.grantsLastYear" value="No">
+                <label for="grantsNo">No</label>
+
+                <label>B.19 Security Guard</label>
+                <input type="radio" id="securityGuardYes" name="schoolCharacteristics.securityGuard" value="Yes">
+                <label for="securityGuardYes">Yes</label>
+                <input type="radio" id="securityGuardNo" name="schoolCharacteristics.securityGuard" value="No">
+                <label for="securityGuardNo">No</label>
+
+                <label>B.20 Ownership</label>
+                <input type="radio" id="ownershipFederal" name="schoolCharacteristics.ownership" value="Federal">
+                <label for="ownershipFederal">Federal</label>
+                <input type="radio" id="ownershipState" name="schoolCharacteristics.ownership" value="State">
+                <label for="ownershipState">State</label>
+                <input type="radio" id="ownershipLGEA" name="schoolCharacteristics.ownership" value="LGEA">
+                <label for="ownershipLGEA">LGEA</label>
+                <input type="radio" id="ownershipCommunity" name="schoolCharacteristics.ownership" value="Community">
+                <label for="ownershipCommunity">Community</label>
+            </fieldset>
+
+            <fieldset>
+                <legend>C. Enrolment</legend>
+                <label for="sss1BirthCert">C.1 Number of students with Birth Certificates in SSS1</label>
+                <input type="number" id="sss1BirthCert" name="enrolment.studentsWithBirthCertificatesSSS1">
+
+                <label for="newEntrantsSSS1">C.2 New entrants into SSS1</label>
+                <input type="number" id="newEntrantsSSS1" name="enrolment.newEntrantsSSS1">
+
+                <label>C.3 Senior Secondary Enrolment by age for the Current Academic Year</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>SS1</th>
+                            <th>SS2</th>
+                            <th>SS3</th>
+                        </tr>
+                        <tr>
+                            <th></th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>No. of streams</td>
+                            <td colspan="2"><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.streams"></td>
+                            <td colspan="2"><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.streams"></td>
+                            <td colspan="2"><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.streams"></td>
+                        </tr>
+                        <tr>
+                            <td>No. of streams with Multigrade teaching</td>
+                            <td colspan="2"><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.multigradeStreams"></td>
+                            <td colspan="2"><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.multigradeStreams"></td>
+                            <td colspan="2"><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.multigradeStreams"></td>
+                        </tr>
+                        <tr>
+                            <td>Below 15 years</td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.below15.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.below15.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.below15.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.below15.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.below15.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.below15.female"></td>
+                        </tr>
+                        <tr>
+                            <td>15 Years</td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.age15.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.age15.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.age15.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.age15.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.age15.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.age15.female"></td>
+                        </tr>
+                        <tr>
+                            <td>16 Years</td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.age16.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.age16.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.age16.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.age16.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.age16.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.age16.female"></td>
+                        </tr>
+                        <tr>
+                            <td>17 Years</td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.age17.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.age17.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.age17.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.age17.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.age17.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.age17.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Above 17 years</td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.above17.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.above17.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.above17.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.above17.female"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.above17.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.above17.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Total</td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.total.male" readonly></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss1.total.female" readonly></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.total.male" readonly></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss2.total.female" readonly></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.total.male" readonly></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.total.female" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>No. Completed SSS 3 for previous year</td>
+                            <td colspan="4"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.completedPreviousYear.male"></td>
+                            <td><input type="number" name="enrolment.seniorSecondaryEnrolment.ss3.completedPreviousYear.female"></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <label>C.4 Students Flow for the Current Academic Year</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Students Flow</th>
+                            <th>SS1</th>
+                            <th>SS2</th>
+                            <th>SS3</th>
+                        </tr>
+                        <tr>
+                            <th></th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Dropout</td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.dropout.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.dropout.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.dropout.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.dropout.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.dropout.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.dropout.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Transfer in</td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.transferIn.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.transferIn.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.transferIn.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.transferIn.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.transferIn.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.transferIn.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Transfer out</td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.transferOut.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.transferOut.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.transferOut.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.transferOut.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.transferOut.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.transferOut.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Repeaters</td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.repeaters.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.repeaters.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.repeaters.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.repeaters.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.repeaters.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.repeaters.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Promoted</td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.promoted.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss1.promoted.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.promoted.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss2.promoted.female"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.promoted.male"></td>
+                            <td><input type="number" name="enrolment.studentFlow.ss3.promoted.female"></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <label>C.5 Students with Special Needs for the Current Academic Year</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Challenge that impacts the ability to learn</th>
+                            <th>SS1</th>
+                            <th>SS2</th>
+                            <th>SS3</th>
+                        </tr>
+                        <tr>
+                            <th></th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Blind / visually impaired</td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.blind.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.blind.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.blind.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.blind.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.blind.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.blind.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Hearing / speech impaired</td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.hearingImpaired.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.hearingImpaired.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.hearingImpaired.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.hearingImpaired.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.hearingImpaired.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.hearingImpaired.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Physically challenged</td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.physicallyChallenged.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.physicallyChallenged.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.physicallyChallenged.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.physicallyChallenged.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.physicallyChallenged.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.physicallyChallenged.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Mentally challenged</td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.mentallyChallenged.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.mentallyChallenged.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.mentallyChallenged.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.mentallyChallenged.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.mentallyChallenged.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.mentallyChallenged.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Albinism</td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.albinism.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.albinism.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.albinism.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.albinism.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.albinism.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.albinism.female"></td>
+                        </tr>
+                        <tr>
+                            <td>Autism</td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.autism.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss1.autism.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.autism.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss2.autism.female"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.autism.male"></td>
+                            <td><input type="number" name="enrolment.studentsWithSpecialNeeds.ss3.autism.female"></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <label>C.6 SSCE examination for the previous Academic Year</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>How many students:</th>
+                            <th colspan="3">WAEC</th>
+                            <th colspan="3">NECO</th>
+                        </tr>
+                        <tr>
+                            <th></th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Total</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>registered for SSCE?</td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.registered.male"></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.registered.female"></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.registered.total" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.registered.male"></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.registered.female"></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.registered.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>took part in the (sat for) SSCE?</td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.sat.male"></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.sat.female"></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.sat.total" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.sat.male"></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.sat.female"></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.sat.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>passed SSCE?</td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.passed.male"></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.passed.female"></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.passed.total" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.passed.male"></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.passed.female"></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.passed.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Total</td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.total.male" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.total.female" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.waec.total.total" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.total.male" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.total.female" readonly></td>
+                            <td><input type="number" name="enrolment.ssceExams.neco.total.total" readonly></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fieldset>
+
+            <fieldset>
+                <legend>B. STAFF (Typo in form, should be D)</legend>
+                <label>B.1 How many non-teachings staff are working at the school?</label>
+                <input type="number" name="staff.nonTeaching.male" placeholder="Male">
+                <input type="number" name="staff.nonTeaching.female" placeholder="Female">
+                <input type="number" name="staff.nonTeaching.total" placeholder="Total" readonly>
+                <label>B.2 How many teachers are working at the school regardless of whether they are currently present or on course or absent</label>
+                <input type="number" name="staff.teaching.male" placeholder="Male">
+                <input type="number" name="staff.teaching.female" placeholder="Female">
+                <input type="number" name="staff.teaching.total" placeholder="Total" readonly>
+                <label>B.3 Information on all staff during the school year</label>
+                <div id="staff-info-container">
+                    <!-- Staff member fields will be dynamically added here -->
+                </div>
+                <button type="button" onclick="addStaff()">Add Staff</button>
+            </fieldset>
+
+            <fieldset>
+                <legend>C. CLASSROOMS (Typo in form, should be E)</legend>
+                <label for="numberOfClassrooms">C.1 How many classrooms are there in the school?</label>
+                <input type="number" id="numberOfClassrooms" name="classrooms.numberOfClassrooms">
+                <label>C.2 Are classes held outside because of insufficient classrooms? If yes, how many?</label>
+                <input type="radio" name="classrooms.classesHeldOutside.held" value="Yes"> Yes
+                <input type="number" name="classrooms.classesHeldOutside.number" placeholder="Number">
+                <input type="radio" name="classrooms.classesHeldOutside.held" value="No"> No
+                <label>C.3 Information on all classrooms</label>
+                <div id="classroom-info-container">
+                    <!-- Classroom fields will be dynamically added here -->
+                </div>
+                <button type="button" onclick="addClassroom()">Add Classroom</button>
+                <label>E.5 Number of rooms other than classrooms are there in the school by type of room</label>
+                <input type="number" name="classrooms.otherRooms.staffRooms" placeholder="Staff rooms">
+                <input type="number" name="classrooms.otherRooms.office" placeholder="Office">
+                <input type="number" name="classrooms.otherRooms.library" placeholder="Library">
+                <input type="number" name="classrooms.otherRooms.laboratories" placeholder="Laboratories">
+                <input type="number" name="classrooms.otherRooms.storeRoom" placeholder="Store room">
+                <input type="number" name="classrooms.otherRooms.others" placeholder="Others">
+            </fieldset>
+
+            <fieldset>
+                <legend>D. FACILITIES (Typo in form, should be F)</legend>
+                <label>F.1 Source(s) of safe drinking water</label>
+                <input type="checkbox" name="facilities.safeDrinkingWater" value="Pipe-borne Water"> Pipe-borne Water
+                <input type="checkbox" name="facilities.safeDrinkingWater" value="Borehole"> Borehole
+                <input type="checkbox" name="facilities.safeDrinkingWater" value="Well"> Well
+                <input type="checkbox" name="facilities.safeDrinkingWater" value="Other"> Other
+                <input type="text" name="facilities.safeDrinkingWaterOther" placeholder="Specify other">
+                <input type="checkbox" name="facilities.safeDrinkingWater" value="No Source of Safe Water"> No Source of Safe Water
+                <label>F.2 Facilities available</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Useable</th>
+                            <th>Not useable</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Toilets</td>
+                            <td><input type="number" name="facilities.availableFacilities.toilets.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.toilets.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Computers</td>
+                            <td><input type="number" name="facilities.availableFacilities.computers.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.computers.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Water Source(s)</td>
+                            <td><input type="number" name="facilities.availableFacilities.waterSources.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.waterSources.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Laboratories</td>
+                            <td><input type="number" name="facilities.availableFacilities.laboratories.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.laboratories.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Classrooms</td>
+                            <td><input type="number" name="facilities.availableFacilities.classrooms.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.classrooms.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Library</td>
+                            <td><input type="number" name="facilities.availableFacilities.library.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.library.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Reading Corner</td>
+                            <td><input type="number" name="facilities.availableFacilities.readingCorner.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.readingCorner.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Play Ground(s)</td>
+                            <td><input type="number" name="facilities.availableFacilities.playgrounds.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.playgrounds.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Wash hand facility</td>
+                            <td><input type="number" name="facilities.availableFacilities.washHandFacility.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.washHandFacility.notUseable"></td>
+                        </tr>
+                        <tr>
+                            <td>Others</td>
+                            <td><input type="number" name="facilities.availableFacilities.others.useable"></td>
+                            <td><input type="number" name="facilities.availableFacilities.others.notUseable"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>F.3 Shared Facilities</label>
+                <input type="checkbox" name="facilities.sharedFacilities.toilets" value="true"> Toilets
+                <input type="checkbox" name="facilities.sharedFacilities.classrooms" value="true"> Classrooms
+                <input type="checkbox" name="facilities.sharedFacilities.computers" value="true"> Computers
+                <input type="checkbox" name="facilities.sharedFacilities.library" value="true"> Library
+                <input type="checkbox" name="facilities.sharedFacilities.waterSources" value="true"> Water Source(s)
+                <input type="checkbox" name="facilities.sharedFacilities.playgrounds" value="true"> Play Ground(s)
+                <input type="checkbox" name="facilities.sharedFacilities.laboratories" value="true"> Laboratories
+                <input type="checkbox" name="facilities.sharedFacilities.washHandFacility" value="true"> Wash hand facility
+                <input type="checkbox" name="facilities.sharedFacilities.others" value="true"> Others
+                <label>F.4 Number of useable toilets units by each type of toilet.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th colspan="3">Used only by students</th>
+                            <th colspan="3">Used only by teachers</th>
+                            <th colspan="3">Used by students and teachers</th>
+                            <th>Total</th>
+                        </tr>
+                        <tr>
+                            <th></th>
+                            <th>Male only</th>
+                            <th>Female only</th>
+                            <th>Mixed</th>
+                            <th>Male only</th>
+                            <th>Female only</th>
+                            <th>Mixed</th>
+                            <th>Male only</th>
+                            <th>Female only</th>
+                            <th>Mixed</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Pit</td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.pit.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.pit.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.pit.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.pit.male"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.pit.female"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.pit.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.pit.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.pit.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.pit.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.total.pit" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Bucket system</td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.bucket.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.bucket.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.bucket.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.bucket.male"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.bucket.female"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.bucket.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.bucket.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.bucket.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.bucket.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.total.bucket" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Water flush</td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.waterFlush.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.waterFlush.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.waterFlush.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.waterFlush.male"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.waterFlush.female"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.waterFlush.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.waterFlush.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.waterFlush.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.waterFlush.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.total.waterFlush" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Others</td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.others.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.others.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentOnly.others.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.others.male"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.others.female"></td>
+                            <td><input type="number" name="facilities.toilets.teacherOnly.others.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.others.male"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.others.female"></td>
+                            <td><input type="number" name="facilities.toilets.studentAndTeacher.others.mixed"></td>
+                            <td><input type="number" name="facilities.toilets.total.others" readonly></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>F.5 Source (s) of power</label>
+                <input type="checkbox" name="facilities.powerSources" value="PHCN/NEPA"> PHCN/NEPA
+                <input type="checkbox" name="facilities.powerSources" value="Generator"> Generator
+                <input type="checkbox" name="facilities.powerSources" value="Solar"> Solar
+                <input type="checkbox" name="facilities.powerSources" value="No source of Power"> No source of Power
+                <label>F.6.1 Health facility</label>
+                <input type="checkbox" name="facilities.healthFacility.type" value="Health Clinic/Sick Bay"> Health Clinic/Sick Bay
+                <input type="checkbox" name="facilities.healthFacility.type" value="First Aid Kit"> First Aid Kit
+                <input type="checkbox" name="facilities.healthFacility.type" value="No Health facility"> No Health facility
+                <label>F.6.2 Does the school have health personnel?</label>
+                <input type="radio" name="facilities.healthFacility.hasPersonnel" value="Yes"> Yes
+                <input type="radio" name="facilities.healthFacility.hasPersonnel" value="No"> No
+                <label>F.7 Safety Facilities</label>
+                <input type="checkbox" name="facilities.safetyFacilities" value="perimeter fence"> perimeter fence
+                <input type="checkbox" name="facilities.safetyFacilities" value="school gate"> school gate
+                <input type="checkbox" name="facilities.safetyFacilities" value="Security guards"> Security guards
+                <input type="checkbox" name="facilities.safetyFacilities" value="Security camera"> Security camera
+                <label>F.8 Agricultural Facilities</label>
+                <input type="checkbox" name="facilities.agriculturalFacilities" value="Poultry Farm"> Poultry Farm
+                <input type="checkbox" name="facilities.agriculturalFacilities" value="Fish Pond"> Fish Pond
+                <input type="checkbox" name="facilities.agriculturalFacilities" value="Piggery Pen"> Piggery Pen
+                <input type="checkbox" name="facilities.agriculturalFacilities" value="School Farm"> School Farm
+                <input type="checkbox" name="facilities.agriculturalFacilities" value="Others"> Others
+                <label>F.9 Additional Classrooms Information</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Class</th>
+                            <th>1 Seater</th>
+                            <th>2 Seater</th>
+                            <th>3 Seater</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>SS 1</td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss1.oneSeater"></td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss1.twoSeater"></td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss1.threeSeater"></td>
+                        </tr>
+                        <tr>
+                            <td>SS 2</td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss2.oneSeater"></td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss2.twoSeater"></td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss2.threeSeater"></td>
+                        </tr>
+                        <tr>
+                            <td>SS 3</td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss3.oneSeater"></td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss3.twoSeater"></td>
+                            <td><input type="number" name="facilities.additionalClassInfo.ss3.threeSeater"></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fieldset>
+
+            <fieldset>
+                <legend>G. NUMBER OF STUDENTS BY SUBJECT.</legend>
+                <div id="subject-enrolment-container">
+                    <!-- Subject enrolment fields will be dynamically added here -->
+                </div>
+                <button type="button" onclick="addSubjectEnrolment()">Add Subject Enrolment</button>
+            </fieldset>
+
+            <fieldset>
+                <legend>H. STUDENT/TEACHER BOOK</legend>
+                <label>H.1.1 NUMBER OF CORE SUBJECT TEXTBOOKS AVAILABLE TO STUDENTS PROVIDED BY GOVERNMENT.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Subject Area</th>
+                            <th>SSS1</th>
+                            <th>SSS2</th>
+                            <th>SSS3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>English Language</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.english.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.english.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.english.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Mathematics</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.mathematics.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.mathematics.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.mathematics.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Civic Education</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.civicEducation.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.civicEducation.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.civicEducation.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Trade Subjects</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.tradeSubjects.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.tradeSubjects.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByGovt.tradeSubjects.sss3"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>H.1.2 NUMBER OF CORE SUBJECT TEXTBOOKS AVAILABLE TO STUDENTS PROVIDED BY ANY OTHER SOURCE.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Subject Area</th>
+                            <th>SSS1</th>
+                            <th>SSS2</th>
+                            <th>SSS3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>English Language</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.english.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.english.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.english.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Mathematics</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.mathematics.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.mathematics.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.mathematics.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Civic Education</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.civicEducation.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.civicEducation.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.civicEducation.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Trade Subjects</td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.tradeSubjects.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.tradeSubjects.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.textbooksByOther.tradeSubjects.sss3"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>H.2.1 NUMBER OF CORE SUBJECT STUDENTS’ TEXTBOOKS MADE AVAILABLE TO TEACHERS IN THE SCHOOL PROVIDED BY GOVERNMENT.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Subject Area</th>
+                            <th>SSS1</th>
+                            <th>SSS2</th>
+                            <th>SSS3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>English Language</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.english.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.english.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.english.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Mathematics</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.mathematics.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.mathematics.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.mathematics.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Civic Education</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.civicEducation.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.civicEducation.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.civicEducation.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Trade Subjects</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.tradeSubjects.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.tradeSubjects.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByGovt.tradeSubjects.sss3"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>H.2.2 NUMBER OF CORE SUBJECT STUDENTS’ TEXTBOOKS MADE AVAILABLE TO TEACHERS IN THE SCHOOL PROVIDED BY ANY OTHER SOURCE.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Subject Area</th>
+                            <th>SSS1</th>
+                            <th>SSS2</th>
+                            <th>SSS3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>English Language</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.english.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.english.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.english.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Mathematics</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.mathematics.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.mathematics.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.mathematics.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Civic Education</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.civicEducation.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.civicEducation.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.civicEducation.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Trade Subjects</td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.tradeSubjects.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.tradeSubjects.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherTextbooksByOther.tradeSubjects.sss3"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>H.3.1 NUMBER OF CORE SUBJECT TEACHERS’ GUIDES AVAILABLE IN THE SCHOOL IN THE CURRENT ACADEMIC YEAR PROVIDED BY GOVERNMENT.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Subject Area</th>
+                            <th>SSS1</th>
+                            <th>SSS2</th>
+                            <th>SSS3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>English Language</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.english.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.english.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.english.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Mathematics</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.mathematics.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.mathematics.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.mathematics.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Civic Education</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.civicEducation.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.civicEducation.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.civicEducation.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Trade Subjects</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.tradeSubjects.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.tradeSubjects.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByGovt.tradeSubjects.sss3"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <label>H.3.2 NUMBER OF CORE SUBJECT TEACHERS’ GUIDES AVAILABLE IN THE SCHOOL IN THE CURRENT ACADEMIC YEAR PROVIDED BY ANY OTHER SOURCE.</label>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Subject Area</th>
+                            <th>SSS1</th>
+                            <th>SSS2</th>
+                            <th>SSS3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>English Language</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.english.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.english.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.english.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Mathematics</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.mathematics.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.mathematics.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.mathematics.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Civic Education</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.civicEducation.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.civicEducation.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.civicEducation.sss3"></td>
+                        </tr>
+                        <tr>
+                            <td>Trade Subjects</td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.tradeSubjects.sss1"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.tradeSubjects.sss2"></td>
+                            <td><input type="number" name="studentTeacherBook.teacherGuidesByOther.tradeSubjects.sss3"></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fieldset>
+
+            <fieldset>
+                <legend>I. TEACHERS QUALIFICATION BY LEVEL OF EDUCATION IN THE CURRENT ACADEMIC YEAR</legend>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Highest Academic qualification</th>
+                            <th>Male</th>
+                            <th>Female</th>
+                            <th>Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Ph.D.</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.phd.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.phd.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.phd.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Masters with Teaching Qualification</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.mastersWithTeaching.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.mastersWithTeaching.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.mastersWithTeaching.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Masters without Teaching Qualification</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.mastersWithoutTeaching.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.mastersWithoutTeaching.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.mastersWithoutTeaching.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Degree with Teaching Qualification</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.degreeWithTeaching.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.degreeWithTeaching.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.degreeWithTeaching.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Degree without Teaching Qualification</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.degreeWithoutTeaching.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.degreeWithoutTeaching.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.degreeWithoutTeaching.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>HND with Teaching Qualification</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.hndWithTeaching.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.hndWithTeaching.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.hndWithTeaching.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>HND without Teaching Qualification</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.hndWithoutTeaching.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.hndWithoutTeaching.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.hndWithoutTeaching.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>NCE</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.nce.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.nce.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.nce.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>OND/Diploma/ND</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.ond.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.ond.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.ond.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Grade II</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.gradeII.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.gradeII.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.gradeII.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>SSCE/WASC/WASSC/GCE</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.ssce.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.ssce.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.ssce.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Below SSCE</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.belowSSCE.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.belowSSCE.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.belowSSCE.total" readonly></td>
+                        </tr>
+                        <tr>
+                            <td>Others</td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.others.male"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.others.female"></td>
+                            <td><input type="number" name="teacherQualificationByLevel.sss.others.total" readonly></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fieldset>
+
+            <fieldset>
+                <legend>I. SCHOOL WELL-BEING (Typo in form, should be J)</legend>
+                <label>H.1 School rules and regulations/guidelines</label>
+                <input type="radio" name="schoolWellBeing.hasRules" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.hasRules" value="NO"> NO
+
+                <label>Do the rules and guidelines in your school cover the following aspects?</label>
+                <label>1. Physical safety in School?</label>
+                <label>a. Bullying ?</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.bullying" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.bullying" value="NO"> NO
+                <label>b. Physical Violence?</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.physicalViolence" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.physicalViolence" value="NO"> NO
+                <label>c. Corporal punishment?</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.corporalPunishment" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.corporalPunishment" value="NO"> NO
+                <label>d. Does the school have security personnel?</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.hasSecurityPersonnel" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.hasSecurityPersonnel" value="NO"> NO
+                <label>e. Does the school have a perimeter fence?</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.hasPerimeterFence" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.hasPerimeterFence" value="NO"> NO
+                <label>f. Has your school been ever attacked?</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.hasBeenAttacked" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.physicalSafety.hasBeenAttacked" value="NO"> NO
+                <label>g. If Yes, how many times has your school been attacked in the last three (3) years?</label>
+                <input type="number" name="schoolWellBeing.rulesCover.physicalSafety.timesAttackedLast3Years">
+                <label>h. Others (please specify)</label>
+                <input type="text" name="schoolWellBeing.rulesCover.physicalSafety.others">
+
+                <label>2. Stigma and discrimination towards:</label>
+                <label>a. learners living with/affected by HIV</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.learnersHIV" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.learnersHIV" value="NO"> NO
+                <label>b. learners based on ethnicity</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.learnersEthnicity" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.learnersEthnicity" value="NO"> NO
+                <label>c. learners that have been harassed/abused</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.learnersHarassed" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.learnersHarassed" value="NO"> NO
+                <label>d. staff living with/affected by HIV</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.staffHIV" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.staffHIV" value="NO"> NO
+                <label>e. staff based on ethnicity</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.staffEthnicity" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.staffEthnicity" value="NO"> NO
+                <label>f. staff that have been harassed/abused</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.staffHarassed" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.stigmaAndDiscrimination.staffHarassed" value="NO"> NO
+
+                <label>3. Grievance/disciplinary procedures in case of breach of the regulation described in the rules and guidelines.</label>
+                <input type="radio" name="schoolWellBeing.rulesCover.grievanceProcedures" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.rulesCover.grievanceProcedures" value="NO"> NO
+
+                <label>H.2 Communication of rules and guidelines</label>
+                <label>Has your school communicated information about the rules and guidelines to learners?</label>
+                <input type="radio" name="schoolWellBeing.communicationOfRules.toLearners" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.communicationOfRules.toLearners" value="NO"> NO
+                <label>Has your school communicated information about the rules and guidelines to teachers?</label>
+                <input type="radio" name="schoolWellBeing.communicationOfRules.toTeachers" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.communicationOfRules.toTeachers" value="NO"> NO
+                <label>Has your school communicated information about the rules and guidelines to parents?</label>
+                <input type="radio" name="schoolWellBeing.communicationOfRules.toParents" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.communicationOfRules.toParents" value="NO"> NO
+
+                <label>H.3 School Well-being Education</label>
+                <label>Did learners in your school receive any form of life-skills-based SWB Education in the previous academic year?</label>
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.receivedLifeSkills" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.receivedLifeSkills" value="NO"> NO
+                <label>If yes, indicate which of these topics were covered</label>
+                <label>a. Teaching on generic life skills</label>
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.genericLifeSkills" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.genericLifeSkills" value="NO"> NO
+                <label>b. Teaching on reproductive health</label>
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.reproductiveHealth" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.reproductiveHealth" value="NO"> NO
+                <label>c. Teaching on HIV transmission and prevention.</label>
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.hivPrevention" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.hivPrevention" value="NO"> NO
+                <label>d. Teaching on Epidemics such as Cholera, Lassa Fever, and others</label>
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.epidemics" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.epidemics" value="NO"> NO
+                <label>e. Teaching on Pandemics such as COVID-19, Ebola and others</label>
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.pandemics" value="YES"> YES
+                <input type="radio" name="schoolWellBeing.wellBeingEducation.topicsCovered.pandemics" value="NO"> NO
+
+                <label>H.4 Number of learners that received/participated in SWB Life Skills in the previous year?</label>
+                <input type="number" name="schoolWellBeing.learnersReceivedSWB.male" placeholder="Male">
+                <input type="number" name="schoolWellBeing.learnersReceivedSWB.female" placeholder="Female">
+
+                <label>H.5 Orientation Process for Parents or Guardians of Learners</label>
+                <label>How many times has your school organized an orientation program for parents or guardians of learners regarding SWB in the previous academic year?</label>
+                <input type="number" name="schoolWellBeing.parentOrientation.timesOrganized">
+                <label>In what fora was the orientation program provided?</label>
+                <input type="checkbox" name="schoolWellBeing.parentOrientation.fora" value="PTA"> PTA
+                <input type="checkbox" name="schoolWellBeing.parentOrientation.fora" value="Open Day"> Open Day
+                <input type="checkbox" name="schoolWellBeing.parentOrientation.fora" value="Special Session(s)"> Special Session(s)
+
+                <label>H.6 Date of Last Orientation</label>
+                <input type="date" name="schoolWellBeing.lastOrientationDate">
+
+                <label>H.7 Life skills-based Well-being: Teacher training</label>
+                <label>How many teachers in your school received formal training on SWB?</label>
+                <input type="number" name="schoolWellBeing.teacherTraining.receivedFormalTraining.male" placeholder="Male">
+                <input type="number" name="schoolWellBeing.teacherTraining.receivedFormalTraining.female" placeholder="Female">
+                <label>How many teachers in your school who received formal training in the previous year also taught related topics on SWB</label>
+                <input type="number" name="schoolWellBeing.teacherTraining.taughtRelatedTopics.male" placeholder="Male">
+                <input type="number" name="schoolWellBeing.teacherTraining.taughtRelatedTopics.female" placeholder="Female">
+            </fieldset>
+
+            <fieldset>
+                <legend>K. UNDERTAKING</legend>
+                <label>Attestation by Principal</label>
+                <input type="text" name="undertaking.principal.name" placeholder="Name">
+                <input type="text" name="undertaking.principal.telephone" placeholder="Telephone">
+                <input type="text" name="undertaking.principal.signature" placeholder="Signature">
+                <input type="date" name="undertaking.principal.date">
+                <label>Attestation by SBMC Chairperson/member</label>
+                <input type="text" name="undertaking.sbmcChairperson.name" placeholder="Name">
+                <input type="text" name="undertaking.sbmcChairperson.position" placeholder="Position">
+                <input type="text" name="undertaking.sbmcChairperson.telephone" placeholder="Telephone">
+                <input type="text" name="undertaking.sbmcChairperson.signature" placeholder="Signature">
+                <input type="date" name="undertaking.sbmcChairperson.date">
+                <label>Attestation by Supervisor</label>
+                <input type="text" name="undertaking.supervisor.name" placeholder="Name">
+                <input type="text" name="undertaking.supervisor.position" placeholder="Position">
+                <input type="text" name="undertaking.supervisor.telephone" placeholder="Telephone">
+                <input type="text" name="undertaking.supervisor.signature" placeholder="Signature">
+                <input type="date" name="undertaking.supervisor.date">
+            </fieldset>
+
+            <button type="submit">Submit</button>
+        </form>
+    </main>
+    <script src="sss.js"></script>
+</body>
+</html>

--- a/sss.js
+++ b/sss.js
@@ -1,0 +1,131 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('sss-form');
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const data = {};
+        const formData = new FormData(form);
+
+        // Helper function to set nested properties
+        const setProperty = (obj, path, value) => {
+            const keys = path.replace(/\[(\w+)\]/g, '.$1').replace(/^\./, '').split('.');
+            let current = obj;
+            for (let i = 0; i < keys.length - 1; i++) {
+                if (!current[keys[i]]) {
+                    current[keys[i]] = isNaN(keys[i + 1]) ? {} : [];
+                }
+                current = current[keys[i]];
+            }
+            current[keys[keys.length - 1]] = value;
+        };
+
+        // Process all form fields
+        for (const [key, value] of formData.entries()) {
+            // Handle checkboxes
+            if (form.elements[key].type === 'checkbox') {
+                if (!data[key]) {
+                    data[key] = [];
+                }
+                data[key].push(value);
+            } else {
+                setProperty(data, key, value);
+            }
+        }
+
+        try {
+            const response = await fetch('/api/sss', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-user-id': localStorage.getItem('userId')
+                },
+                body: JSON.stringify(data)
+            });
+
+            if (response.ok) {
+                alert('Form submitted successfully!');
+                form.reset();
+            } else {
+                const errorData = await response.json();
+                alert(`Error submitting form: ${errorData.message}`);
+            }
+        } catch (error) {
+            console.error('Error submitting form:', error);
+            alert('An error occurred while submitting the form.');
+        }
+    });
+});
+
+function addStaff() {
+    const container = document.getElementById('staff-info-container');
+    const staffIndex = container.children.length;
+    const staffHtml = `
+        <div class="staff-member">
+            <input type="text" name="staff.staffInfo[${staffIndex}].staffFileNo" placeholder="Staff File No">
+            <input type="text" name="staff.staffInfo[${staffIndex}].name" placeholder="Name of staff">
+            <select name="staff.staffInfo[${staffIndex}].gender">
+                <option value="M">Male</option>
+                <option value="F">Female</option>
+            </select>
+            <input type="text" name="staff.staffInfo[${staffIndex}].type" placeholder="Type of staff">
+            <input type="text" name="staff.staffInfo[${staffIndex}].sourceOfSalary" placeholder="Source of salary">
+            <input type="number" name="staff.staffInfo[${staffIndex}].yearOfBirth" placeholder="Year of birth">
+            <input type="number" name="staff.staffInfo[${staffIndex}].yearOfFirstAppointment" placeholder="Year of first appointment">
+            <input type="number" name="staff.staffInfo[${staffIndex}].yearOfPresentAppointment" placeholder="Year of present appointment">
+            <input type="number" name="staff.staffInfo[${staffIndex}].yearOfPosting" placeholder="Year of posting to this school">
+            <input type="text" name="staff.staffInfo[${staffIndex}].gradeLevelStep" placeholder="Grade level / Step">
+            <input type="text" name="staff.staffInfo[${staffIndex}].present" placeholder="Present">
+            <input type="text" name="staff.staffInfo[${staffIndex}].academicQualification" placeholder="Academic Qualification">
+            <input type="text" name="staff.staffInfo[${staffIndex}].teachingQualification" placeholder="Teaching Qualification">
+            <input type="text" name="staff.staffInfo[${staffIndex}].subjectOfQualification" placeholder="Subject of qualification">
+            <input type="text" name="staff.staffInfo[${staffIndex}].mainSubjectTaught" placeholder="Main subject taught">
+            <input type="text" name="staff.staffInfo[${staffIndex}].teachingType" placeholder="Teaching type">
+            <input type="checkbox" name="staff.staffInfo[${staffIndex}].teachesJuniorSecondary" value="true"> Teaches junior secondary
+            <input type="number" name="staff.staffInfo[${staffIndex}].trainingsLast12Months" placeholder="Trainings in last 12 months">
+        </div>
+    `;
+    container.insertAdjacentHTML('beforeend', staffHtml);
+}
+
+function addClassroom() {
+    const container = document.getElementById('classroom-info-container');
+    const classroomIndex = container.children.length;
+    const classroomHtml = `
+        <div class="classroom">
+            <input type="number" name="classrooms.classroomInfo[${classroomIndex}].yearOfConstruction" placeholder="Year of construction">
+            <input type="text" name="classrooms.classroomInfo[${classroomIndex}].presentCondition" placeholder="Present condition">
+            <input type="number" name="classrooms.classroomInfo[${classroomIndex}].length" placeholder="Length (m)">
+            <input type="number" name="classrooms.classroomInfo[${classroomIndex}].width" placeholder="Width (m)">
+            <input type="text" name="classrooms.classroomInfo[${classroomIndex}].floorMaterial" placeholder="Floor material">
+            <input type="text" name="classrooms.classroomInfo[${classroomIndex}].wallMaterial" placeholder="Walls material">
+            <input type="text" name="classrooms.classroomInfo[${classroomIndex}].roofMaterial" placeholder="Roof material">
+            <select name="classrooms.classroomInfo[${classroomIndex}].seating">
+                <option value="Yes">Yes</option>
+                <option value="No">No</option>
+            </select>
+            <select name="classrooms.classroomInfo[${classroomIndex}].goodBlackboard">
+                <option value="Yes">Yes</option>
+                <option value="No">No</option>
+            </select>
+        </div>
+    `;
+    container.insertAdjacentHTML('beforeend', classroomHtml);
+}
+
+function addSubjectEnrolment() {
+    const container = document.getElementById('subject-enrolment-container');
+    const subjectIndex = container.children.length;
+    const subjectHtml = `
+        <div class="subject-enrolment">
+            <input type="text" name="subjectEnrolment[${subjectIndex}].subject" placeholder="Subject">
+            <input type="number" name="subjectEnrolment[${subjectIndex}].ss1.male" placeholder="SS1 Male">
+            <input type="number" name="subjectEnrolment[${subjectIndex}].ss1.female" placeholder="SS1 Female">
+            <input type="number" name="subjectEnrolment[${subjectIndex}].ss2.male" placeholder="SS2 Male">
+            <input type="number" name="subjectEnrolment[${subjectIndex}].ss2.female" placeholder="SS2 Female">
+            <input type="number" name="subjectEnrolment[${subjectIndex}].ss3.male" placeholder="SS3 Male">
+            <input type="number" name="subjectEnrolment[${subjectIndex}].ss3.female" placeholder="SS3 Female">
+        </div>
+    `;
+    container.insertAdjacentHTML('beforeend', subjectHtml);
+}


### PR DESCRIPTION
This commit introduces a new feature: the Senior Secondary School (SSS) census form.

The changes include:
- A new `sss.html` file with the complete form structure.
- A corresponding `sss.js` file to handle client-side form logic, including dynamic fields and submission.
- An update to `forms.html` to include a link to the new SSS form.
- A new Mongoose model (`models/sss.js`) to define the data schema for the SSS form.
- Updates to `server.js` to:
  - Serve the `sss.html` file.
  - Add an API endpoint (`/api/sss`) to handle form submissions.
  - Integrate SSS form data into the main dashboard's data aggregation endpoint (`/api/data`).

The new form has been tested to ensure it renders correctly, submits data successfully, and integrates with the existing dashboard.