### PR TITLE
fix(server): Include eccdeForms in chart data aggregation

### DIFF
--- a/server.js
+++ b/server.js
@@ -475,6 +475,13 @@ app.get('/api/data', async (req, res) => {
                 }
             });
         });
+        eccdeForms.forEach(s => {
+            s.staff?.staffInfo?.forEach(staff => {
+                if (staff.academicQualification) {
+                    qualificationCounts[staff.academicQualification] = (qualificationCounts[staff.academicQualification] || 0) + 1;
+                }
+            });
+        });
 
         const electricityCounts = {};
         surveys.forEach(s => {
@@ -534,6 +541,16 @@ app.get('/api/data', async (req, res) => {
             });
         });
         sssForms.forEach(s => {
+            s.staff?.staffInfo?.forEach(staff => {
+                const gender = staff.gender?.toUpperCase();
+                if (gender === 'M') {
+                    genderCounts.Male++;
+                } else if (gender === 'F') {
+                    genderCounts.Female++;
+                }
+            });
+        });
+        eccdeForms.forEach(s => {
             s.staff?.staffInfo?.forEach(staff => {
                 const gender = staff.gender?.toUpperCase();
                 if (gender === 'M') {


### PR DESCRIPTION
The main dashboard charts were not reflecting data from submitted ECCDE forms. This was because the `/api/data` endpoint was not including `eccdeForms` when aggregating data for the `genderCounts` and `qualificationCounts`.

This change updates the data aggregation logic in `server.js` to correctly include the `eccdeForms` data, ensuring that the charts on the main dashboard are accurate and up-to-date.