### PR TITLE
feat: Add temporary logging to debug login issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -247,21 +247,34 @@ app.delete('/api/user/:id', isAdmin, async (req, res) => {
 app.post('/api/login', async (req, res) => {
     try {
         const { username, password } = req.body;
+        console.log(`[DEBUG] Login attempt for username: ${username}`);
+
         const user = await User.findOne({ username });
         if (!user) {
+            console.log(`[DEBUG] User not found: ${username}`);
             return res.status(401).json({ message: 'Invalid credentials' });
         }
 
+        console.log(`[DEBUG] User found. Stored password hash: ${user.password}`);
+
         user.comparePassword(password, (err, isMatch) => {
             if (err) {
+                console.error('[DEBUG] bcrypt error during password comparison:', err);
                 return res.status(500).json({ message: 'Error logging in', error: err });
             }
+
+            console.log(`[DEBUG] Password comparison result (isMatch): ${isMatch}`);
+
             if (!isMatch) {
+                console.log(`[DEBUG] Password mismatch for user: ${username}`);
                 return res.status(401).json({ message: 'Invalid credentials' });
             }
+
+            console.log(`[DEBUG] Login successful for user: ${username}`);
             res.json({ message: 'Login successful', user: { id: user._id, username: user.username, role: user.role } });
         });
     } catch (error) {
+        console.error('[DEBUG] Catch block error in /api/login:', error);
         res.status(500).json({ message: 'Error logging in', error });
     }
 });


### PR DESCRIPTION
Adds detailed logging to the /api/login route to help diagnose a persistent '401 Unauthorized' error. This includes logging the user lookup, the stored password hash, and the result of the bcrypt password comparison.

This is a temporary measure for debugging and the logging should be removed once the issue is resolved.