### PR TITLE
Fix: Update survey data handling to display on dashboard

### DIFF
--- a/models/Survey.js
+++ b/models/Survey.js
@@ -73,6 +73,13 @@ const surveySchema = new mongoose.Schema({
     electricity: String,
     waterlogged: String,
     photos: [String],
+    staffProfile: [{
+        name: String,
+        qualification: String,
+        specialization: String,
+        experience: Number,
+        trcn: String
+    }],
     createdAt: {
         type: Date,
         default: Date.now

--- a/survey.html
+++ b/survey.html
@@ -65,7 +65,7 @@
             </div>
             <div>
                 <label for="lga">Local Govt:</label>
-                <select id="lga" name="lga" required>
+                <select id="lga" name="lgea" required>
                     <option value="">Select LGA</option>
                 </select>
             </div>
@@ -81,7 +81,7 @@
             </div>
             <div>
                 <label for="address">Address</label>
-                <input type="text" id="address" name="address" required>
+                <input type="text" id="address" name="schoolAddress" required>
             </div>
             <div>
                 <label for="latitude">Latitude</label>


### PR DESCRIPTION
This commit addresses an issue where submitted survey data was not being displayed on the dashboard. The root cause was a mismatch between the updated survey form and the backend's data processing and storage logic.

The following changes have been made:
1.  **Updated `survey.html`:** Corrected form field names (`lga` to `lgea`, `address` to `schoolAddress`) to align with the database schema.
2.  **Enhanced `models/Survey.js`:** Added a `staffProfile` array to the `Survey` schema to store detailed staff information from the new form.
3.  **Adapted `server.js`:**
    -   Modified the `/api/survey` endpoint to correctly parse and save the new `staffProfile` data.
    -   Updated the `/api/data` aggregation logic to use the new `staffProfile` for the 'Highest Qualifications' chart and to handle the absence of gender data in the new survey form.