### PR TITLE
Remove Survey hyperlink from top navigation bar

### DIFF
--- a/audit-log.html
+++ b/audit-log.html
@@ -20,7 +20,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/eccde-form.html
+++ b/eccde-form.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/eccde-reports.html
+++ b/eccde-reports.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/forms.html
+++ b/forms.html
@@ -21,7 +21,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/jss-reports.html
+++ b/jss-reports.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/science-report">Science Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>

--- a/jss.html
+++ b/jss.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/private-reports.html
+++ b/private-reports.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/science-report">Science Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>

--- a/profile.html
+++ b/profile.html
@@ -28,7 +28,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/reports.html
+++ b/reports.html
@@ -21,7 +21,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/science-report.html
+++ b/science-report.html
@@ -15,7 +15,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/science.html
+++ b/science.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/sss-reports.html
+++ b/sss-reports.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/science-report">Science Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>

--- a/sss.html
+++ b/sss.html
@@ -14,7 +14,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/science-report">Science Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>

--- a/survey.html
+++ b/survey.html
@@ -29,7 +29,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>

--- a/users.html
+++ b/users.html
@@ -28,7 +28,6 @@
                 <li><a href="/">Dashboard</a></li>
                 <li><a href="/users">Users</a></li>
                 <li><a href="/profile">Profile</a></li>
-                <li><a href="/survey">Survey</a></li>
                 <li><a href="/reports">Reports</a></li>
                 <li><a href="/audit-log">Audit Log</a></li>
                 <li><a href="/forms">School Census Forms</a></li>


### PR DESCRIPTION
This commit removes the "Survey" hyperlink from the top navigation bar in all relevant HTML files.