### PR TITLE
Fix: Correct logout functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,6 +170,7 @@ function populatePrivateSchoolTable(data) {
 
 function logout() {
     sessionStorage.removeItem('loggedIn');
+    sessionStorage.removeItem('user');
     window.location.href = 'login.html';
 }
 


### PR DESCRIPTION
The logout button was not working correctly because the `logout` function only removed the `loggedIn` item from `sessionStorage`, leaving the `user` object behind. This caused the application to still consider the user as logged in.

This commit updates the `logout` function in `script.js` to remove both the `loggedIn` and `user` items from `sessionStorage`, ensuring a complete logout.