### PR TITLE
Feat: Prevent negative numbers in number fields

### DIFF
--- a/header.js
+++ b/header.js
@@ -69,4 +69,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     }
+
+    const numberInputs = document.querySelectorAll('input[type="number"]');
+    numberInputs.forEach(input => {
+        input.min = 0;
+    });
 });


### PR DESCRIPTION
This change adds a JavaScript snippet to `header.js` that sets the `min` attribute of all number input fields to `0`. This prevents users from entering negative values in any of the forms across the application.