### PR TITLE
Fix: Ensure user ID is sent in form submissions

### DIFF
--- a/eccde-form.js
+++ b/eccde-form.js
@@ -222,10 +222,17 @@ document.addEventListener('DOMContentLoaded', () => {
             setProperty(structuredData, key, value);
         }
 
+        const user = JSON.parse(sessionStorage.getItem('user'));
+        if (!user || !user.id) {
+            alert('You must be logged in to submit this form.');
+            return;
+        }
+
         fetch('/api/eccde-form', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                'x-user-id': user.id,
             },
             body: JSON.stringify(structuredData),
         })

--- a/jss.js
+++ b/jss.js
@@ -149,11 +149,17 @@ document.addEventListener('DOMContentLoaded', () => {
         // so the data object should be correctly structured.
 
         try {
+            const user = JSON.parse(sessionStorage.getItem('user'));
+            if (!user || !user.id) {
+                alert('You must be logged in to submit this form.');
+                return;
+            }
+
             const response = await fetch('/api/jss', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'x-user-id': localStorage.getItem('userId')
+                    'x-user-id': user.id
                 },
                 body: JSON.stringify(data)
             });

--- a/private-form.js
+++ b/private-form.js
@@ -342,11 +342,17 @@ async function handleFormSubmission(event) {
 
 
     try {
+        const user = JSON.parse(sessionStorage.getItem('user'));
+        if (!user || !user.id) {
+            alert('You must be logged in to submit this form.');
+            return;
+        }
+
         const response = await fetch('/api/private-survey', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'x-user-id': localStorage.getItem('userId')
+                'x-user-id': user.id
             },
             body: JSON.stringify(data)
         });

--- a/science.js
+++ b/science.js
@@ -283,12 +283,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
+            const user = JSON.parse(sessionStorage.getItem('user'));
+            if (!user || !user.id) {
+                alert('You must be logged in to submit this form.');
+                return;
+            }
+
             // Submit the structured data
             fetch('/api/science', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'x-user-id': JSON.parse(sessionStorage.getItem('user'))?.id
+                    'x-user-id': user.id
                 },
                 body: JSON.stringify(data)
             })

--- a/sss.js
+++ b/sss.js
@@ -142,11 +142,17 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         try {
+            const user = JSON.parse(sessionStorage.getItem('user'));
+            if (!user || !user.id) {
+                alert('You must be logged in to submit this form.');
+                return;
+            }
+
             const response = await fetch('/api/sss', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'x-user-id': localStorage.getItem('userId')
+                    'x-user-id': user.id
                 },
                 body: JSON.stringify(data)
             });


### PR DESCRIPTION
Previously, several form submission scripts were either not sending the user ID or were attempting to retrieve it from the wrong storage location (localStorage instead of sessionStorage). This caused an 'Error verifying access rights' error because the backend middleware requires the 'x-user-id' header for authorization.

This commit standardizes the logic across all relevant form scripts (`eccde-form.js`, `private-form.js`, `science.js`, `jss.js`, and `sss.js`) to correctly retrieve the user object from sessionStorage, verify that the user is logged in, and include the user's ID in the 'x-user-id' header of the request.