### PR TITLE
fix(auth): Include user ID in API requests to resolve 401 error

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,14 +25,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Authentication check
-    if (sessionStorage.getItem('loggedIn') !== 'true') {
+    const loggedIn = sessionStorage.getItem('loggedIn') === 'true';
+    const user = JSON.parse(sessionStorage.getItem('user') || 'null');
+
+    if (!loggedIn || !user || !user.id) {
+        // If not properly logged in, clear session and redirect to login.
+        sessionStorage.removeItem('loggedIn');
+        sessionStorage.removeItem('user');
         window.location.href = 'login.html';
         return;
     }
 
     const brandColors = getBrandColors();
 
-    fetch('/api/data')
+    fetch('/api/data', {
+        headers: {
+            'x-user-id': user.id
+        }
+    })
         .then(response => {
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
This change addresses a '401 Unauthorized' error that occurred when fetching dashboard data. The issue was caused by the client not sending the required 'x-user-id' header with the API request.

The fix involves updating 'script.js' to:
- Retrieve the user's ID from sessionStorage.
- Include the 'x-user-id' in the headers of the fetch request to '/api/data'.
- Add a robust authentication check to prevent crashes when the user's session is invalid.