### PR TITLE
fix(reports): Use sessionStorage to prevent logout on page load

### DIFF
--- a/reports.js
+++ b/reports.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', async () => {
     const loadingDiv = document.getElementById('loading');
     const dashboardContent = document.getElementById('dashboard-content');
-    const user = JSON.parse(localStorage.getItem('user'));
+    const user = JSON.parse(sessionStorage.getItem('user'));
 
     if (!user || !user.id) {
         window.location.href = '/login.html';


### PR DESCRIPTION
The reports page was incorrectly using `localStorage` to check for user authentication, while the rest of the application uses `sessionStorage`. This discrepancy caused the reports page to fail to find the user's session data, resulting in the user being redirected to the login page.

This commit aligns the reports page with the rest of the application by switching to `sessionStorage` for authentication checks. This ensures a consistent user experience and prevents unintended logouts.