### PR TITLE
Fix: Ensure reports are correctly filtered for enumerators

### DIFF
--- a/server.js
+++ b/server.js
@@ -466,7 +466,7 @@ app.get('/api/jss-reports', isAdminOrEnumerator, async (req, res) => {
     try {
         const query = {};
         if (req.user.role === 'enumerator') {
-            query.submittedBy = req.user.id;
+            query.submittedBy = new mongoose.Types.ObjectId(req.user.id);
         }
         const reports = await Jss.find(query).sort({ createdAt: -1 });
         res.json(reports);
@@ -479,7 +479,7 @@ app.get('/api/private-reports', isAdminOrEnumerator, async (req, res) => {
     try {
         const query = {};
         if (req.user.role === 'enumerator') {
-            query.submittedBy = req.user.id;
+            query.submittedBy = new mongoose.Types.ObjectId(req.user.id);
         }
         const reports = await PrivateSurvey.find(query).sort({ createdAt: -1 });
         res.json(reports);
@@ -492,7 +492,7 @@ app.get('/api/sss-reports', isAdminOrEnumerator, async (req, res) => {
     try {
         const query = {};
         if (req.user.role === 'enumerator') {
-            query.submittedBy = req.user.id;
+            query.submittedBy = new mongoose.Types.ObjectId(req.user.id);
         }
         const reports = await Sss.find(query).sort({ createdAt: -1 });
         res.json(reports);
@@ -505,7 +505,7 @@ app.get('/api/eccde-reports', isAdminOrEnumerator, async (req, res) => {
     try {
         const query = {};
         if (req.user.role === 'enumerator') {
-            query.submittedBy = req.user.id;
+            query.submittedBy = new mongoose.Types.ObjectId(req.user.id);
         }
         const reports = await Eccde.find(query).sort({ createdAt: -1 });
         res.json(reports);
@@ -518,7 +518,7 @@ app.get('/api/science-reports', isAdminOrEnumerator, async (req, res) => {
     try {
         const query = {};
         if (req.user.role === 'enumerator') {
-            query.submittedBy = req.user.id;
+            query.submittedBy = new mongoose.Types.ObjectId(req.user.id);
         }
         const reports = await Science.find(query).sort({ createdAt: -1 });
         res.json(reports);


### PR DESCRIPTION
The report-fetching endpoints were failing to display data for enumerators because of a type mismatch in the database query. The `submittedBy` field, which is an ObjectId, was being compared to a string user ID.

This commit corrects the query by casting the string user ID to a Mongoose ObjectId before executing the find operation. The fix is applied to all relevant report endpoints to ensure consistent behavior.