### PR TITLE
Fix JavaScript errors on dashboard and science pages

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,0 +1,10 @@
+function showSuccessPopup(message) {
+    const popup = document.createElement('div');
+    popup.className = 'success-popup';
+    popup.textContent = message;
+    document.body.appendChild(popup);
+
+    setTimeout(() => {
+        popup.remove();
+    }, 3000);
+}

--- a/science.html
+++ b/science.html
@@ -1281,6 +1281,7 @@
         <p>Lagos State Universal Basic Education Board © 2025. All Rights Reserved. | Centre of Excellence</p>
     </footer>
     <script src="script.js"></script>
+    <script src="common.js"></script>
     <script src="science.js"></script>
     <script src="logout.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -25,33 +25,35 @@ document.addEventListener('DOMContentLoaded', () => {
         }, 3000);
     }
 
-    const user = JSON.parse(sessionStorage.getItem('user'));
-    if (!user || !user.id) {
-        window.location.href = 'login.html';
-        return;
-    }
-
-    fetch('/api/data', {
-        headers: {
-            'Content-Type': 'application/json',
-            'x-user-id': user.id
-        }
-    })
-    .then(response => {
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        return response.json();
-    })
-    .then(data => {
-        if (data.noData) {
-            document.querySelector('.dashboard').innerHTML = '<p>No survey data available to display.</p>';
+    if (document.getElementById('key-metrics')) {
+        const user = JSON.parse(sessionStorage.getItem('user'));
+        if (!user || !user.id) {
+            window.location.href = 'login.html';
             return;
         }
-        updateDashboard(data);
-    })
-    .catch(error => {
-        console.error('Error fetching or processing dashboard data:', error);
-        document.querySelector('.dashboard').innerHTML = `<p>Error loading dashboard data. Please try again later. Details: ${error.message}</p>`;
-    });
+
+        fetch('/api/data', {
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': user.id
+            }
+        })
+        .then(response => {
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            return response.json();
+        })
+        .then(data => {
+            if (data.noData) {
+                document.querySelector('.dashboard').innerHTML = '<p>No survey data available to display.</p>';
+                return;
+            }
+            updateDashboard(data);
+        })
+        .catch(error => {
+            console.error('Error fetching or processing dashboard data:', error);
+            document.querySelector('.dashboard').innerHTML = `<p>Error loading dashboard data. Please try again later. Details: ${error.message}</p>`;
+        });
+    }
 });
 
 function updateDashboard(data) {


### PR DESCRIPTION
- Refactored `script.js` to only execute dashboard-related code when dashboard elements are present. This prevents `TypeError` on other pages.
- Created `common.js` with a `showSuccessPopup` function to handle success notifications.
- Included `common.js` in `science.html` to resolve the `ReferenceError` when submitting the form.