### PR TITLE
Fix: Include common.js in private_form.html

### DIFF
--- a/private_form.html
+++ b/private_form.html
@@ -425,6 +425,7 @@
     </main>
     <script src="header.js"></script>
     <script src="script.js"></script>
+    <script src="common.js"></script>
     <script src="private-form.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The script `private-form.js` uses the function `showSuccessPopup`, which is defined in `common.js`. However, `private_form.html` was not including `common.js`, leading to a `ReferenceError: showSuccessPopup is not defined` when submitting the form.

This commit adds the necessary script tag for `common.js` to `private_form.html`, ensuring that the `showSuccessPopup` function is available when called.