### PR TITLE
fix: Include common.js in eccde-form.html to resolve ReferenceError

### DIFF
--- a/eccde-form.html
+++ b/eccde-form.html
@@ -1476,6 +1476,7 @@
     </main>
     <script src="header.js"></script>
 
+    <script src="common.js"></script>
     <script src="eccde-form.js"></script>
     <script src="logout.js"></script>
 </body>


### PR DESCRIPTION
The eccde-form.js script relies on the showSuccessPopup function, which is defined in common.js. However, common.js was not included in eccde-form.html, leading to a ReferenceError when the form submission was successful.

This commit adds the necessary script tag for common.js, ensuring that showSuccessPopup is defined before it is called.