### PR TITLE
feat: Replace user avatar with a CSS-based user icon

### DIFF
--- a/header.js
+++ b/header.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     &#9776;
                 </button>
                 <div id="user-profile">
-                    <img id="user-avatar" src="" alt="User Avatar">
+                    <span id="user-icon" class="user-icon"></span>
                     <span id="user-name"></span>
                 </div>
             </div>
@@ -58,12 +58,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (user) {
         const userName = document.getElementById('user-name');
-        const userAvatar = document.getElementById('user-avatar');
         if (userName) {
             userName.textContent = user.fullName || user.username;
-        }
-        if (userAvatar) {
-            // userAvatar.src = user.profilePicture || 'default-avatar.png';
         }
 
         // Role-based access control for navigation

--- a/style.css
+++ b/style.css
@@ -165,12 +165,39 @@ th {
     align-items: center;
 }
 
-#user-avatar {
+.user-icon {
+    display: inline-block;
     width: 40px;
     height: 40px;
     border-radius: 50%;
+    background-color: #ccc;
     margin-right: 10px;
-    object-fit: cover;
+    position: relative;
+    overflow: hidden;
+}
+
+.user-icon::before {
+    content: '';
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background-color: white;
+}
+
+.user-icon::after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 30px;
+    height: 20px;
+    border-radius: 50% 50% 0 0;
+    background-color: white;
 }
 
 #user-name {


### PR DESCRIPTION
Replaces the user avatar image in the header with a generic, CSS-only user icon.

- Modifies `header.js` to replace the `<img>` tag with a `<span>` for the icon.
- Removes the JavaScript logic that dynamically set the avatar's `src`.
- Adds CSS to `style.css` to style the new `<span>` as a user icon using pseudo-elements for the head and shoulders.