### PR TITLE
Fix server startup by adding DATABASE_URL config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,5 @@ services:
     envVars:
       - key: NODE_VERSION
         value: "14.17.0" # You can change this to your desired Node.js version
+      - key: DATABASE_URL
+        value: "your_mongodb_connection_string_here" # IMPORTANT: Replace with your actual MongoDB connection string


### PR DESCRIPTION
The application was failing to start due to a missing DATABASE_URL environment variable, which is required for the MongoDB connection. This likely caused the 503 Service Unavailable error.

This commit adds the DATABASE_URL environment variable to the `render.yaml` file.

IMPORTANT: The value for DATABASE_URL is a placeholder. You must replace "your_mongodb_connection_string_here" with your actual MongoDB connection string for the application to work. It is highly recommended to set this as a secret environment variable in your Render dashboard rather than committing the actual key to the file.